### PR TITLE
Setup TBDocs

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -90,3 +90,35 @@ jobs:
 
       - name: Run tests for all packages
         run: pnpm test:browser
+
+  tbdocs-reporter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build all workspace packages
+        run: pnpm build
+
+      - name: TBDocs Reporter
+        id: tbdocs-reporter-protocol
+        uses: TBD54566975/tbdocs@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          project_path: "./packages/protocol"
+          docs_reporter: "api-extractor"
+          fail_on_error: false

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,43 +32,46 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-      - name: install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - name: test
+        run: echo "success"
 
-      - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
+      # - name: install pnpm
+      #   uses: pnpm/action-setup@v2
+      #   with:
+      #     version: 8
 
-      - name: Install dependencies
-        run: pnpm install
+      # - name: Set up Node.js
+      #   uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+      #   with:
+      #     node-version: 20
+      #     registry-url: https://registry.npmjs.org/
 
-      - name: Build all workspace packages
-        run: pnpm build
+      # - name: Install dependencies
+      #   run: pnpm install
 
-      - name: TBDocs Reporter and Generator
-        id: tbdocs-reporter-generator
-        uses: TBD54566975/tbdocs@main
-        with:
-          bot_app_id: ${{ secrets.TBDOCS_BOT_APP_ID }}
-          bot_app_private_key: ${{ secrets.TBDOCS_BOT_APP_PRIVATE_KEY }}
-          bot_app_installation_id: ${{ secrets.TBDOCS_BOT_APP_INSTALLATION_ID }}
-          project_path: "./packages/protocol"
-          docs_reporter: api-extractor
-          fail_on_error: true
-          fail_on_warnings: false
-          docs_generator: 'typedoc-markdown'
-          docs_target_owner_repo: 'TBD54566975/developer.tbd.website'
-          docs_target_branch: 'tbdocs-bot/tbdex-js/protocol'
-          docs_target_pr_base_branch: 'main'
-          docs_target_repo_path: 'site/docs/tbdex/tbdex-js/protocol'
+      # - name: Build all workspace packages
+      #   run: pnpm build
+
+      # - name: TBDocs Reporter and Generator
+      #   id: tbdocs-reporter-generator
+      #   uses: TBD54566975/tbdocs@main
+      #   with:
+      #     bot_app_id: ${{ secrets.TBDOCS_BOT_APP_ID }}
+      #     bot_app_private_key: ${{ secrets.TBDOCS_BOT_APP_PRIVATE_KEY }}
+      #     bot_app_installation_id: ${{ secrets.TBDOCS_BOT_APP_INSTALLATION_ID }}
+      #     project_path: "./packages/protocol"
+      #     docs_reporter: api-extractor
+      #     fail_on_error: true
+      #     fail_on_warnings: false
+      #     docs_generator: 'typedoc-markdown'
+      #     docs_target_owner_repo: 'TBD54566975/developer.tbd.website'
+      #     docs_target_branch: 'tbdocs-bot/tbdex-js/protocol'
+      #     docs_target_pr_base_branch: 'main'
+      #     docs_target_repo_path: 'site/docs/tbdex/tbdex-js/protocol'
 
   publish-npm:
     needs: tbdocs-publish
-    if: ${{ (github.event.inputs.jobSelector == 'all' && needs.tbdocs-publish.result == 'success') || (github.event.inputs.jobSelector == 'npm' && always())}}
+    if: ${{ (github.event.inputs.jobSelector == 'all' && needs.tbdocs-publish.result == 'success') || (github.event.inputs.jobSelector == 'npm')}}
     name: NPM Publish
     runs-on: ubuntu-latest
 
@@ -86,63 +89,66 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-      - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
+      - name: test
+        run: echo "test"
 
-      - name: Install latest npm
-        run: npm install -g npm@latest
+      # - name: Set up Node.js
+      #   uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+      #   with:
+      #     node-version: 20
+      #     registry-url: https://registry.npmjs.org/
 
-      - name: Install semver utility
-        run: npm install -g semver@7.5.1
+      # - name: Install latest npm
+      #   run: npm install -g npm@latest
 
-      # Note - this is not required but it gives a clean failure prior to attempting a release if the GH workflow runner is not authenticated with NPMjs.com
-      - name: Verify NPM token is authenticated with NPMjs.com
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-        run: npm whoami
+      # - name: Install semver utility
+      #   run: npm install -g semver@7.5.1
 
-      - name: Check if GitHub repo package version is latest
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-        run: |
-          cd packages/${{ matrix.package }}
+      # # Note - this is not required but it gives a clean failure prior to attempting a release if the GH workflow runner is not authenticated with NPMjs.com
+      # - name: Verify NPM token is authenticated with NPMjs.com
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      #   run: npm whoami
 
-          # Fetch the published version on NPMjs.com.
-          PUBLISHED_VERSION=$(npm view @tbdex/${{ matrix.package }} version 2>/dev/null || echo "0.0.0")
-          echo "Published Version: $PUBLISHED_VERSION"
+      # - name: Check if GitHub repo package version is latest
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      #   run: |
+      #     cd packages/${{ matrix.package }}
 
-          # Fetch the version in the GitHub repo's package.json file.
-          REPO_VERSION=$(node -p "require('./package.json').version")
-          echo "REPO_VERSION=$REPO_VERSION" >> $GITHUB_ENV
-          echo "Repo Version: $REPO_VERSION"
+      #     # Fetch the published version on NPMjs.com.
+      #     PUBLISHED_VERSION=$(npm view @tbdex/${{ matrix.package }} version 2>/dev/null || echo "0.0.0")
+      #     echo "Published Version: $PUBLISHED_VERSION"
 
-          # Compare the repo and NPMjs.com package versions.
-          IS_GREATER=$(semver --range ">$PUBLISHED_VERSION" $REPO_VERSION || true)
-          if [ -n "$IS_GREATER" ] ; then
-            echo "@tbdex/${{ matrix.package }}@$REPO_VERSION is latest"
-            echo "IS_LATEST=true" >> $GITHUB_ENV
-          else
-            echo "@tbdex/${{ matrix.package }}@$REPO_VERSION is already published or repo version is lower"
-            echo "IS_LATEST=false" >> $GITHUB_ENV
-          fi
-        shell: bash
+      #     # Fetch the version in the GitHub repo's package.json file.
+      #     REPO_VERSION=$(node -p "require('./package.json').version")
+      #     echo "REPO_VERSION=$REPO_VERSION" >> $GITHUB_ENV
+      #     echo "Repo Version: $REPO_VERSION"
 
-      - name: Install dependencies
-        if: env.IS_LATEST == 'true'
-        run: npm ci
+      #     # Compare the repo and NPMjs.com package versions.
+      #     IS_GREATER=$(semver --range ">$PUBLISHED_VERSION" $REPO_VERSION || true)
+      #     if [ -n "$IS_GREATER" ] ; then
+      #       echo "@tbdex/${{ matrix.package }}@$REPO_VERSION is latest"
+      #       echo "IS_LATEST=true" >> $GITHUB_ENV
+      #     else
+      #       echo "@tbdex/${{ matrix.package }}@$REPO_VERSION is already published or repo version is lower"
+      #       echo "IS_LATEST=false" >> $GITHUB_ENV
+      #     fi
+      #   shell: bash
 
-      - name: Build all workspace packages
-        if: env.IS_LATEST == 'true'
-        run: npm run build
+      # - name: Install dependencies
+      #   if: env.IS_LATEST == 'true'
+      #   run: npm ci
 
-      - name: Publish @tbdex/${{ matrix.package }}@${{ env.REPO_VERSION }}
-        if: env.IS_LATEST == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-        run: |
-          cd packages/${{ matrix.package }}
-          npm publish --access public --provenance
-        shell: bash
+      # - name: Build all workspace packages
+      #   if: env.IS_LATEST == 'true'
+      #   run: npm run build
+
+      # - name: Publish @tbdex/${{ matrix.package }}@${{ env.REPO_VERSION }}
+      #   if: env.IS_LATEST == 'true'
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      #   run: |
+      #     cd packages/${{ matrix.package }}
+      #     npm publish --access public --provenance
+      #   shell: bash

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,9 +1,18 @@
-name: Publish Packages to NPM
+name: Publish Packages to NPM and TBDocs
 
 on:
   release:
     types: [created]
   workflow_dispatch:
+    inputs:
+      jobSelector:
+        type: choice
+        description: 'Select publishing options'
+        required: true
+        options:
+          - 'all'
+          - 'docs'
+          - 'npm'
 
 # Allow only one concurrent deployment,but do NOT cancel in-progress runs as
 # we want to allow these release deployments to complete.
@@ -16,7 +25,50 @@ permissions:
   id-token: write # necessary for NPM provenance
 
 jobs:
+  tbdocs-publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.jobSelector == 'all' || github.event.inputs.jobSelector == 'docs' }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build all workspace packages
+        run: pnpm build
+
+      - name: TBDocs Reporter and Generator
+        id: tbdocs-reporter-generator
+        uses: TBD54566975/tbdocs@main
+        with:
+          bot_app_id: ${{ secrets.TBDOCS_BOT_APP_ID }}
+          bot_app_private_key: ${{ secrets.TBDOCS_BOT_APP_PRIVATE_KEY }}
+          bot_app_installation_id: ${{ secrets.TBDOCS_BOT_APP_INSTALLATION_ID }}
+          project_path: "./packages/protocol"
+          docs_reporter: api-extractor
+          fail_on_error: true
+          fail_on_warnings: false
+          docs_generator: 'typedoc-markdown'
+          docs_target_owner_repo: 'TBD54566975/developer.tbd.website'
+          docs_target_branch: 'tbdocs-bot/tbdex-js/protocol'
+          docs_target_pr_base_branch: 'main'
+          docs_target_repo_path: 'site/docs/tbdex/tbdex-js/protocol'
+
   publish-npm:
+    needs: tbdocs-publish
+    if: ${{ (github.event.inputs.jobSelector == 'all' && needs.tbdocs-publish.result == 'success') || (github.event.inputs.jobSelector == 'npm' && always())}}
     name: NPM Publish
     runs-on: ubuntu-latest
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,46 +32,43 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-      - name: test
-        run: echo "success"
+      - name: install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
 
-      # - name: install pnpm
-      #   uses: pnpm/action-setup@v2
-      #   with:
-      #     version: 8
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
 
-      # - name: Set up Node.js
-      #   uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-      #   with:
-      #     node-version: 20
-      #     registry-url: https://registry.npmjs.org/
+      - name: Install dependencies
+        run: pnpm install
 
-      # - name: Install dependencies
-      #   run: pnpm install
+      - name: Build all workspace packages
+        run: pnpm build
 
-      # - name: Build all workspace packages
-      #   run: pnpm build
-
-      # - name: TBDocs Reporter and Generator
-      #   id: tbdocs-reporter-generator
-      #   uses: TBD54566975/tbdocs@main
-      #   with:
-      #     bot_app_id: ${{ secrets.TBDOCS_BOT_APP_ID }}
-      #     bot_app_private_key: ${{ secrets.TBDOCS_BOT_APP_PRIVATE_KEY }}
-      #     bot_app_installation_id: ${{ secrets.TBDOCS_BOT_APP_INSTALLATION_ID }}
-      #     project_path: "./packages/protocol"
-      #     docs_reporter: api-extractor
-      #     fail_on_error: true
-      #     fail_on_warnings: false
-      #     docs_generator: 'typedoc-markdown'
-      #     docs_target_owner_repo: 'TBD54566975/developer.tbd.website'
-      #     docs_target_branch: 'tbdocs-bot/tbdex-js/protocol'
-      #     docs_target_pr_base_branch: 'main'
-      #     docs_target_repo_path: 'site/docs/tbdex/tbdex-js/protocol'
+      - name: TBDocs Reporter and Generator
+        id: tbdocs-reporter-generator
+        uses: TBD54566975/tbdocs@main
+        with:
+          bot_app_id: ${{ secrets.TBDOCS_BOT_APP_ID }}
+          bot_app_private_key: ${{ secrets.TBDOCS_BOT_APP_PRIVATE_KEY }}
+          bot_app_installation_id: ${{ secrets.TBDOCS_BOT_APP_INSTALLATION_ID }}
+          project_path: "./packages/protocol"
+          docs_reporter: api-extractor
+          fail_on_error: true
+          fail_on_warnings: false
+          docs_generator: 'typedoc-markdown'
+          docs_target_owner_repo: 'TBD54566975/developer.tbd.website'
+          docs_target_branch: 'tbdocs-bot/tbdex-js/protocol'
+          docs_target_pr_base_branch: 'main'
+          docs_target_repo_path: 'site/docs/tbdex/tbdex-js/protocol'
 
   publish-npm:
     needs: tbdocs-publish
-    if: ${{ (github.event.inputs.jobSelector == 'all' && needs.tbdocs-publish.result == 'success') || (github.event.inputs.jobSelector == 'npm')}}
+    if: ${{ (github.event.inputs.jobSelector == 'all' && needs.tbdocs-publish.result == 'success') || (github.event.inputs.jobSelector == 'npm' && always())}}
     name: NPM Publish
     runs-on: ubuntu-latest
 
@@ -89,66 +86,63 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-      - name: test
-        run: echo "test"
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
 
-      # - name: Set up Node.js
-      #   uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-      #   with:
-      #     node-version: 20
-      #     registry-url: https://registry.npmjs.org/
+      - name: Install latest npm
+        run: npm install -g npm@latest
 
-      # - name: Install latest npm
-      #   run: npm install -g npm@latest
+      - name: Install semver utility
+        run: npm install -g semver@7.5.1
 
-      # - name: Install semver utility
-      #   run: npm install -g semver@7.5.1
+      # Note - this is not required but it gives a clean failure prior to attempting a release if the GH workflow runner is not authenticated with NPMjs.com
+      - name: Verify NPM token is authenticated with NPMjs.com
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+        run: npm whoami
 
-      # # Note - this is not required but it gives a clean failure prior to attempting a release if the GH workflow runner is not authenticated with NPMjs.com
-      # - name: Verify NPM token is authenticated with NPMjs.com
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-      #   run: npm whoami
+      - name: Check if GitHub repo package version is latest
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+        run: |
+          cd packages/${{ matrix.package }}
 
-      # - name: Check if GitHub repo package version is latest
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-      #   run: |
-      #     cd packages/${{ matrix.package }}
+          # Fetch the published version on NPMjs.com.
+          PUBLISHED_VERSION=$(npm view @tbdex/${{ matrix.package }} version 2>/dev/null || echo "0.0.0")
+          echo "Published Version: $PUBLISHED_VERSION"
 
-      #     # Fetch the published version on NPMjs.com.
-      #     PUBLISHED_VERSION=$(npm view @tbdex/${{ matrix.package }} version 2>/dev/null || echo "0.0.0")
-      #     echo "Published Version: $PUBLISHED_VERSION"
+          # Fetch the version in the GitHub repo's package.json file.
+          REPO_VERSION=$(node -p "require('./package.json').version")
+          echo "REPO_VERSION=$REPO_VERSION" >> $GITHUB_ENV
+          echo "Repo Version: $REPO_VERSION"
 
-      #     # Fetch the version in the GitHub repo's package.json file.
-      #     REPO_VERSION=$(node -p "require('./package.json').version")
-      #     echo "REPO_VERSION=$REPO_VERSION" >> $GITHUB_ENV
-      #     echo "Repo Version: $REPO_VERSION"
+          # Compare the repo and NPMjs.com package versions.
+          IS_GREATER=$(semver --range ">$PUBLISHED_VERSION" $REPO_VERSION || true)
+          if [ -n "$IS_GREATER" ] ; then
+            echo "@tbdex/${{ matrix.package }}@$REPO_VERSION is latest"
+            echo "IS_LATEST=true" >> $GITHUB_ENV
+          else
+            echo "@tbdex/${{ matrix.package }}@$REPO_VERSION is already published or repo version is lower"
+            echo "IS_LATEST=false" >> $GITHUB_ENV
+          fi
+        shell: bash
 
-      #     # Compare the repo and NPMjs.com package versions.
-      #     IS_GREATER=$(semver --range ">$PUBLISHED_VERSION" $REPO_VERSION || true)
-      #     if [ -n "$IS_GREATER" ] ; then
-      #       echo "@tbdex/${{ matrix.package }}@$REPO_VERSION is latest"
-      #       echo "IS_LATEST=true" >> $GITHUB_ENV
-      #     else
-      #       echo "@tbdex/${{ matrix.package }}@$REPO_VERSION is already published or repo version is lower"
-      #       echo "IS_LATEST=false" >> $GITHUB_ENV
-      #     fi
-      #   shell: bash
+      - name: Install dependencies
+        if: env.IS_LATEST == 'true'
+        run: npm ci
 
-      # - name: Install dependencies
-      #   if: env.IS_LATEST == 'true'
-      #   run: npm ci
+      - name: Build all workspace packages
+        if: env.IS_LATEST == 'true'
+        run: npm run build
 
-      # - name: Build all workspace packages
-      #   if: env.IS_LATEST == 'true'
-      #   run: npm run build
-
-      # - name: Publish @tbdex/${{ matrix.package }}@${{ env.REPO_VERSION }}
-      #   if: env.IS_LATEST == 'true'
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-      #   run: |
-      #     cd packages/${{ matrix.package }}
-      #     npm publish --access public --provenance
-      #   shell: bash
+      - name: Publish @tbdex/${{ matrix.package }}@${{ env.REPO_VERSION }}
+        if: env.IS_LATEST == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+        run: |
+          cd packages/${{ matrix.package }}
+          npm publish --access public --provenance
+        shell: bash


### PR DESCRIPTION
Install [tbdocs-action](https://github.com/TBD54566975/tbdocs) which will have two main functionalities:

1. **Docs Reporter**: every PR against main will report the doc warnings and errors in the PR comment. The developer can feel free to correct them if they want to or ignore it for now. After releasing the v1 we should make this blocking.

2. **Publishing Docs to the developer.tbd.website**: on the Publish workflow now you have three options:
a. Publish npm: like it is today
b. Publish docs: will run the docs reporter (from step 1) and if it completes without errors it will generate the markdown files and open a PR to our website repo: https://github.com/TBD54566975/developer.tbd.website
c. Publish both: this will try to publish the docs by opening the PR, if it succeeds it will publish to npm, otherwise it will fail.

Proposed design can be found here: [TBD OSP Automated Docs Pipeline Proposal](https://hackmd.io/@leordev/Byf3R5_J6)

I've already addressed the points raised from @KendallWeihe on my forked repo example [here](https://github.com/leordev/tbdex-js/pull/2)

And this is what we get automagically:
- Automated PR: https://github.com/TBD54566975/developer.tbd.website/pull/796
- Preview of the docs: https://deploy-preview-796--tbd-website-developer.netlify.app/docs/tbdex/tbdex-js/protocol/