### PR TITLE
Add @tbdex-js/protocol package doc

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -64,7 +64,7 @@ jobs:
           docs_target_owner_repo: 'TBD54566975/developer.tbd.website'
           docs_target_branch: 'tbdocs-bot/tbdex-js/protocol'
           docs_target_pr_base_branch: 'main'
-          docs_target_repo_path: 'site/docs/tbdex/tbdex-js/protocol'
+          docs_target_repo_path: 'site/docs/tbdex/api-reference/tbdex-js/protocol'
 
   publish-npm:
     needs: tbdocs-publish

--- a/packages/protocol/src/main.ts
+++ b/packages/protocol/src/main.ts
@@ -1,15 +1,24 @@
-import { messageFactory, resourceFactory } from './utils.js'
-import { Resource } from './resource.js'
-import { Message } from './message.js'
+/**
+ * Library that can be used to create, parse, verify, and validate
+ * the tbDEX Messages and Resources defined in the
+ * [protocol specification](https://github.com/TBD54566975/tbdex-protocol/blob/main/README.md).
+ *
+ * [Link to GitHub Repo](https://github.com/TBD54566975/tbdex-js/tree/main/packages/protocol)
+ *
+ * @packageDocumentation
+ */
 
-Message.factory = messageFactory
-Resource.factory = resourceFactory
+import { messageFactory, resourceFactory } from "./utils.js";
+import { Resource } from "./resource.js";
+import { Message } from "./message.js";
 
-export * from './resource-kinds/index.js'
-export * from './message-kinds/index.js'
-export * from './did-resolver.js'
-export * from './dev-tools.js'
-export * from './crypto.js'
-export * from './types.js'
-export { Message, Resource }
+Message.factory = messageFactory;
+Resource.factory = resourceFactory;
 
+export * from "./resource-kinds/index.js";
+export * from "./message-kinds/index.js";
+export * from "./did-resolver.js";
+export * from "./dev-tools.js";
+export * from "./crypto.js";
+export * from "./types.js";
+export { Message, Resource };

--- a/packages/protocol/src/main.ts
+++ b/packages/protocol/src/main.ts
@@ -8,17 +8,17 @@
  * @packageDocumentation
  */
 
-import { messageFactory, resourceFactory } from "./utils.js";
-import { Resource } from "./resource.js";
-import { Message } from "./message.js";
+import { messageFactory, resourceFactory } from './utils.js'
+import { Resource } from './resource.js'
+import { Message } from './message.js'
 
-Message.factory = messageFactory;
-Resource.factory = resourceFactory;
+Message.factory = messageFactory
+Resource.factory = resourceFactory
 
-export * from "./resource-kinds/index.js";
-export * from "./message-kinds/index.js";
-export * from "./did-resolver.js";
-export * from "./dev-tools.js";
-export * from "./crypto.js";
-export * from "./types.js";
-export { Message, Resource };
+export * from './resource-kinds/index.js'
+export * from './message-kinds/index.js'
+export * from './did-resolver.js'
+export * from './dev-tools.js'
+export * from './crypto.js'
+export * from './types.js'
+export { Message, Resource }


### PR DESCRIPTION
It adds a brief summary and link to the repo on the index of the protocol docs.

As per request here: https://github.com/TBD54566975/tbdocs/issues/28

Using the `@packageDocumentation` was the key tag to add this summary in the docs!

Preview Link: https://deploy-preview-804--tbd-website-developer.netlify.app/docs/tbdex/api-reference/tbdex-js/protocol/

Summary preview:
<img width="1394" alt="image" src="https://github.com/TBD54566975/tbdex-js/assets/6147142/b41f415f-23bd-4aff-b706-79486df784c3">
