### PR TITLE
Filter tbdocs-reporter to only changed files

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: TBDocs Reporter
         id: tbdocs-reporter-protocol
-        uses: TBD54566975/tbdocs@leordev/issue-25.report-changed-scope
+        uses: TBD54566975/tbdocs@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           project_path: "./packages/protocol"

--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -116,9 +116,10 @@ jobs:
 
       - name: TBDocs Reporter
         id: tbdocs-reporter-protocol
-        uses: TBD54566975/tbdocs@main
+        uses: TBD54566975/tbdocs@leordev/issue-25.report-changed-scope
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           project_path: "./packages/protocol"
           docs_reporter: "api-extractor"
+          report_changed_scope_only: true
           fail_on_error: false

--- a/packages/protocol/src/crypto.ts
+++ b/packages/protocol/src/crypto.ts
@@ -61,7 +61,7 @@ export class Crypto {
    *  )
    * )
    * TODO: add link to tbdex protocol hash section
-   * @param payload the payload to hash
+   * @param payload - the payload to hash
    */
   static hash(payload: any) {
     const cborEncodedPayloadBuffer = cbor.encode(payload)

--- a/packages/protocol/src/crypto.ts
+++ b/packages/protocol/src/crypto.ts
@@ -61,7 +61,7 @@ export class Crypto {
    *  )
    * )
    * TODO: add link to tbdex protocol hash section
-   * @param payload - the payload to hash
+   * @param payload the payload to hash
    */
   static hash(payload: any) {
     const cborEncodedPayloadBuffer = cbor.encode(payload)


### PR DESCRIPTION
Introduces the flag `report_changed_scope_only: true`, which will filter the tbdocs reporter to show only the modified lines by the PR.

Working evidence:
![image](https://github.com/TBD54566975/tbdex-js/assets/6147142/9550b07e-ce7f-40da-b655-05ab3eaf735b)
