### PR TITLE
Remove protocol exports from http-client and http-server

### DIFF
--- a/.changeset/beige-icons-cheer.md
+++ b/.changeset/beige-icons-cheer.md
@@ -1,0 +1,6 @@
+---
+"@tbdex/http-client": minor
+"@tbdex/http-server": minor
+---
+
+Changed 'protocol' to a 'peerDependecies'

--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -4,8 +4,12 @@ An HTTP client that can be used to send tbdex messages to PFIs
 
 # Installation
 ```bash
-npm install @tbdex/http-client
+npm install @tbdex/http-client @tbdex/protocol
 ```
+
+> [!NOTE]
+>
+> `@tbdex/protocol` is a [peer dependency](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies) to `@tbdex/http-client`
 
 # Usage
 ```typescript

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -49,13 +49,13 @@
     }
   },
   "dependencies": {
-    "@tbdex/protocol": "workspace:*",
     "@web5/crypto": "0.2.0",
     "@web5/dids": "0.2.0",
     "query-string": "8.1.0"
   },
   "devDependencies": {
     "@playwright/test": "1.34.3",
+    "@tbdex/protocol": "workspace:*",
     "@types/chai": "4.3.5",
     "@types/eslint": "8.37.0",
     "@types/mocha": "10.0.1",
@@ -80,6 +80,9 @@
     "typedoc": "0.25.0",
     "typedoc-plugin-markdown": "3.16.0",
     "typescript": "5.2.2"
+  },
+  "peerDependencies": {
+    "@tbdex/protocol": "workspace:*"
   },
   "scripts": {
     "clean": "rimraf dist tests/compiled",

--- a/packages/http-client/src/main.ts
+++ b/packages/http-client/src/main.ts
@@ -6,6 +6,5 @@
  * @packageDocumentation
  */
 
-export * from '@tbdex/protocol'
 export * from './client.js'
 export * from './types.js'

--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -7,8 +7,13 @@ A configurable implementation of the [tbdex http api draft specification](https:
 
 # Installation
 ```bash
-npm install @tbdex/http-server
+npm install @tbdex/http-server @tbdex/protocol
 ```
+
+> [!NOTE]
+>
+> `@tbdex/protocol` is a [peer dependency](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies) to `@tbdex/http-server`
+
 # Usage
 ```typescript
 import { TbdexHttpServer } from '@tbdex/http-server'

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -21,12 +21,12 @@
     "import": "./dist/main.js"
   },
   "dependencies": {
+    "@tbdex/http-client": "workspace:*",
     "@web5/dids": "0.2.0",
     "cors": "2.8.5",
     "express": "4.18.2"
   },
   "devDependencies": {
-    "@tbdex/http-client": "workspace:*",
     "@tbdex/protocol": "workspace:*",
     "@types/chai": "4.3.6",
     "@types/express": "4.17.17",
@@ -40,7 +40,6 @@
     "undici": "5.26.3"
   },
   "peerDependencies": {
-    "@tbdex/http-client": "workspace:*",
     "@tbdex/protocol": "workspace:*"
   },
   "scripts": {

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -21,13 +21,13 @@
     "import": "./dist/main.js"
   },
   "dependencies": {
-    "@tbdex/http-client": "workspace:*",
-    "@tbdex/protocol": "workspace:*",
     "@web5/dids": "0.2.0",
     "cors": "2.8.5",
     "express": "4.18.2"
   },
   "devDependencies": {
+    "@tbdex/http-client": "workspace:*",
+    "@tbdex/protocol": "workspace:*",
     "@types/chai": "4.3.6",
     "@types/express": "4.17.17",
     "@types/http-errors": "^2.0.1",
@@ -38,6 +38,10 @@
     "supertest": "6.3.3",
     "typescript": "5.2.2",
     "undici": "5.26.3"
+  },
+  "peerDependencies": {
+    "@tbdex/http-client": "workspace:*",
+    "@tbdex/protocol": "workspace:*"
   },
   "scripts": {
     "build": "pnpm clean && tsc",

--- a/packages/http-server/src/main.ts
+++ b/packages/http-server/src/main.ts
@@ -6,6 +6,5 @@
  * @packageDocumentation
  */
 
-export * from '@tbdex/http-client'
 export * from './http-server.js'
 export * from './types.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
 
   packages/http-server:
     dependencies:
+      '@tbdex/http-client':
+        specifier: workspace:*
+        version: link:../http-client
       '@web5/dids':
         specifier: 0.2.0
         version: 0.2.0
@@ -142,9 +145,6 @@ importers:
         specifier: 4.18.2
         version: 4.18.2
     devDependencies:
-      '@tbdex/http-client':
-        specifier: workspace:*
-        version: link:../http-client
       '@tbdex/protocol':
         specifier: workspace:*
         version: link:../protocol

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
 
   packages/http-client:
     dependencies:
-      '@tbdex/protocol':
-        specifier: workspace:*
-        version: link:../protocol
       '@web5/crypto':
         specifier: 0.2.0
         version: 0.2.0
@@ -57,6 +54,9 @@ importers:
       '@playwright/test':
         specifier: 1.34.3
         version: 1.34.3
+      '@tbdex/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       '@types/chai':
         specifier: 4.3.5
         version: 4.3.5
@@ -132,12 +132,6 @@ importers:
 
   packages/http-server:
     dependencies:
-      '@tbdex/http-client':
-        specifier: workspace:*
-        version: link:../http-client
-      '@tbdex/protocol':
-        specifier: workspace:*
-        version: link:../protocol
       '@web5/dids':
         specifier: 0.2.0
         version: 0.2.0
@@ -148,6 +142,12 @@ importers:
         specifier: 4.18.2
         version: 4.18.2
     devDependencies:
+      '@tbdex/http-client':
+        specifier: workspace:*
+        version: link:../http-client
+      '@tbdex/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       '@types/chai':
         specifier: 4.3.6
         version: 4.3.6


### PR DESCRIPTION
Discussions from this PR w/ @leordev led us to the conclusion that `http-client` and `http-server` shouldn't export transitive abstractions; which is to say, abstractions from a different dependency

@mistermoe would this break anything? Open to push back on this topic