### PR TITLE
Automate GitHub releases

### DIFF
--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -1,0 +1,59 @@
+name: Create GH Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+  workflow_dispatch:
+
+# Allow only one concurrent deployment,but do NOT cancel in-progress runs as
+# we want to allow these release deployments to complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    # a gh release will be created in the following conditions:
+    # 1. if it is a manual trigger (workflow_dispatch)
+    # 2. if the workflow was triggered by a merged changeset PR
+    if: |
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+        (github.event.pull_request.head.ref == 'changeset-release/main' ||
+        contains(github.event.pull_request.labels.*.name, 'automated-release'))))
+    name: Create GH Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
+      - name: Check if GitHub repo package version is latest
+        run: |
+          # get any package version from the repo
+          cd packages/protocol
+
+          # Fetch the version in the GitHub repo's package.json file.
+          REPO_VERSION=$(node -p "require('./package.json').version")
+          echo "REPO_VERSION=$REPO_VERSION" >> $GITHUB_ENV
+          echo "Repo Version: $REPO_VERSION"
+        shell: bash
+
+      # TODO: uncomment before merging
+    #   - name: Create GitHub Release
+    #     uses: softprops/action-gh-release@v1
+    #     with:
+    #       name: v${{ env.REPO_VERSION }}
+    #       tag_name: v${{ env.REPO_VERSION }}
+    #       draft: true
+    #       prerelease: true
+    #       generate_release_notes: true

--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          name: v${{ env.REPO_VERSION }}
-          tag_name: v${{ env.REPO_VERSION }}
-          draft: true
-          prerelease: true
+          name: v${{ env.REPO_VERSION }}-test
+          tag_name: v${{ env.REPO_VERSION }}-test
+          draft: false
+          prerelease: false
           generate_release_notes: true

--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          name: v${{ env.REPO_VERSION }}-test
-          tag_name: v${{ env.REPO_VERSION }}-test
+          name: v${{ env.REPO_VERSION }}
+          tag_name: v${{ env.REPO_VERSION }}
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -48,12 +48,11 @@ jobs:
           echo "Repo Version: $REPO_VERSION"
         shell: bash
 
-      # TODO: uncomment before merging
-    #   - name: Create GitHub Release
-    #     uses: softprops/action-gh-release@v1
-    #     with:
-    #       name: v${{ env.REPO_VERSION }}
-    #       tag_name: v${{ env.REPO_VERSION }}
-    #       draft: true
-    #       prerelease: true
-    #       generate_release_notes: true
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ env.REPO_VERSION }}
+          tag_name: v${{ env.REPO_VERSION }}
+          draft: true
+          prerelease: true
+          generate_release_notes: true

--- a/.github/workflows/create-gh-release.yml
+++ b/.github/workflows/create-gh-release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Check if GitHub repo package version is latest
         run: |
           # get any package version from the repo
-          cd packages/protocol
+          cd packages/protocol # assumption that all packages have the same version
 
           # Fetch the version in the GitHub repo's package.json file.
           REPO_VERSION=$(node -p "require('./package.json').version")

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,15 +4,6 @@ on:
   release:
     types: [created]
   workflow_dispatch:
-    inputs:
-      jobSelector:
-        type: choice
-        description: "Select publishing options"
-        required: true
-        options:
-          - "all"
-          - "docs"
-          - "npm"
 
 # Allow only one concurrent deployment,but do NOT cancel in-progress runs as
 # we want to allow these release deployments to complete.
@@ -25,59 +16,7 @@ permissions:
   id-token: write # necessary for NPM provenance
 
 jobs:
-  tbdocs-publish:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.jobSelector == 'all' || github.event.inputs.jobSelector == 'docs' }}
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-
-      - name: install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-
-      - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build all workspace packages
-        run: pnpm build
-
-      - name: TBDocs Reporter and Generator
-        id: tbdocs-reporter-generator
-        uses: TBD54566975/tbdocs@main
-        with:
-          bot_app_id: ${{ secrets.TBDOCS_BOT_APP_ID }}
-          bot_app_private_key: ${{ secrets.TBDOCS_BOT_APP_PRIVATE_KEY }}
-          bot_app_installation_id: ${{ secrets.TBDOCS_BOT_APP_INSTALLATION_ID }}
-          fail_on_error: true
-          fail_on_warnings: false
-          docs_target_owner_repo: "TBD54566975/developer.tbd.website"
-          docs_target_branch: "tbdocs-bot/tbdex-js/packages"
-          docs_target_pr_base_branch: "main"
-          entry_points: |
-            - file: packages/protocol/src/main.ts
-              docsReporter: api-extractor
-              docsGenerator: typedoc-markdown
-              targetRepoPath: site/docs/tbdex/api-reference/tbdex-js/protocol
-            - file: packages/http-client/src/main.ts
-              docsReporter: api-extractor
-              docsGenerator: typedoc-markdown
-              targetRepoPath: site/docs/tbdex/api-reference/tbdex-js/http-client
-            - file: packages/http-server/src/main.ts
-              docsReporter: api-extractor
-              docsGenerator: typedoc-markdown
-              targetRepoPath: site/docs/tbdex/api-reference/tbdex-js/http-server
-
   publish-npm:
-    needs: tbdocs-publish
-    if: ${{ (github.event.inputs.jobSelector == 'all' && needs.tbdocs-publish.result == 'success') || (github.event.inputs.jobSelector == 'npm' && always())}}
     name: NPM Publish
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ Upon opening a Pull Request, the `changeset-bot` will automatically comment ([ex
 
 Prior to merging your branch into main, and given you have relevant semantic versioning changes, then you should run `pnpm changeset` locally. The CLI tool will walk you through a set of steps for you to define the semantic changes. This will create a randomly-named (and funnily-named) markdown file within the `.changeset/` directory. For example, see the `.changeset/sixty-tables-cheat.md` file on [this PR](https://github.com/TBD54566975/tbdex-js/pull/35/files). There is an analogy to staging a commit (using `git add`) for these markdown files, in that, they exist so that the developer can codify the semantic changes made but they don't actually update the semantic version.
 
-Whereafter, a `pnpm changeset version` command must be executed. This command will do two things: update the version numbers in the relevant `package.json` files & also aggregate Summary notes into the relevant `CHANGELOG.md` files. In keeping with the staged commit analogy, this is akin to the actual commit. You **do not need to execute this** prior to merging your changes into the main branch. We have a GitHub Actions workflow (which uses the [Action offered by Changesets](https://github.com/changesets/action)) to automate this process.
-
-It is recommended to merge your branch into main with the `.changeset/*.md` files, at which point, the Changeset GitHub Action will automatically pick up those changes and open a PR to automate the `pnpm changeset version` execution. For example, [see this PR](https://github.com/TBD54566975/tbdex-js/pull/36).
+**You can stop here!** It is recommended to merge your branch into main with the `.changeset/*.md` files, at which point, the Changeset GitHub Action will automatically pick up those changes and open a PR to automate the `pnpm changeset version` execution. For example, [see this PR](https://github.com/TBD54566975/tbdex-js/pull/36). This command will do two things: update the version numbers in the relevant `package.json` files & also aggregate Summary notes into the relevant `CHANGELOG.md` files. In keeping with the staged commit analogy, this is akin to the actual commit.
 
 ## Cutting Releases
 
@@ -89,9 +87,9 @@ Also, by creating the GH release, the packages will be automatically published t
 Recap of the above changesets, plus the release process:
 
 1. Open a PR
-1. `changeset-bot` will automatically [comment on the PR](https://github.com/TBD54566975/tbdex-js/pull/30#issuecomment-1732721942) with a reminder & recommendations for semver
-1. Run `pnpm changeset` locally and push changes (`.changet/*.md`)
-1. Merge PR into `main`
-1. Profit from the release automation:
+2. `changeset-bot` will automatically [comment on the PR](https://github.com/TBD54566975/tbdex-js/pull/30#issuecomment-1732721942) with a reminder & recommendations for semver
+3. Run `pnpm changeset` locally and push changes (`.changet/*.md`)
+4. Merge PR into `main`
+5. Profit from the release automation:
    - [Create GH Release Workflow](./.github/workflows/create-gh-release.yml) will automatically create a new [GitHub Release](https://github.com/TBD54566975/tbdex-js/releases)
    - [NPM Publish Workflow](./.github/workflows/npm-publish.yml) will automatically publish a [new version to NPM](https://www.npmjs.com/package/@tbdex/protocol?activeTab=versions)

--- a/README.md
+++ b/README.md
@@ -72,4 +72,26 @@ Prior to merging your branch into main, and given you have relevant semantic ver
 
 Whereafter, a `pnpm changeset version` command must be executed. This command will do two things: update the version numbers in the relevant `package.json` files & also aggregate Summary notes into the relevant `CHANGELOG.md` files. In keeping with the staged commit analogy, this is akin to the actual commit. You **do not need to execute this** prior to merging your changes into the main branch. We have a GitHub Actions workflow (which uses the [Action offered by Changesets](https://github.com/changesets/action)) to automate this process.
 
-It is recommended to merge your branch into main with the `.changet/*.md` files, at which point, the Changeset GitHub Action will automatically pick up those changes and open a PR to automate the `pnpm changeset version` execution. For example, [see this PR](https://github.com/TBD54566975/tbdex-js/pull/36).
+It is recommended to merge your branch into main with the `.changeset/*.md` files, at which point, the Changeset GitHub Action will automatically pick up those changes and open a PR to automate the `pnpm changeset version` execution. For example, [see this PR](https://github.com/TBD54566975/tbdex-js/pull/36).
+
+## Cutting Releases
+
+When a changeset PR is merged to main we will automatically create a GitHub release using the workflow [Create GH Release](./.github/workflows/create-gh-release.yml).
+
+> [!NOTE]
+>
+> This is done by detecting the merged PR branch name: `changeset-release/main`.
+
+Also, by creating the GH release, the packages will be automatically published to npm. So this way the engineer can simply just merge the changeset PR and the new GH Release and packages version will be automagically published to npm!
+
+## Steps for a new release publish
+
+Recap of the above changesets, plus the release process:
+
+1. Open a PR
+1. `changeset-bot` will automatically [comment on the PR](https://github.com/TBD54566975/tbdex-js/pull/30#issuecomment-1732721942) with a reminder & recommendations for semver
+1. Run `pnpm changeset` locally and push changes (`.changet/*.md`)
+1. Merge PR into `main`
+1. Profit from the release automation:
+   - [Create GH Release Workflow](./.github/workflows/create-gh-release.yml) will automatically create a new [GitHub Release](https://github.com/TBD54566975/tbdex-js/releases)
+   - [NPM Publish Workflow](./.github/workflows/npm-publish.yml) will automatically publish a [new version to NPM](https://www.npmjs.com/package/@tbdex/protocol?activeTab=versions)


### PR DESCRIPTION
This PR automates the trigger to create a GH Release when a changeset PR is merged.

Fix #60 (see full context context).

(Also it removes the TBDocs from the release pipeline because now we are planning to release default Typedoc similar to the  DWN ones).

