### PR TITLE
Refactor sign

### DIFF
--- a/.changeset/seven-bears-stare.md
+++ b/.changeset/seven-bears-stare.md
@@ -1,0 +1,7 @@
+---
+"@tbdex/http-client": minor
+"@tbdex/http-server": minor
+"@tbdex/protocol": minor
+---
+
+Refactored `sign` to take `PortableDid` as an argument instead of `privateKeyJwk` and `kid`

--- a/packages/http-server/tests/get-exchanges.spec.ts
+++ b/packages/http-server/tests/get-exchanges.spec.ts
@@ -65,7 +65,7 @@ describe('GET /exchanges', () => {
     const testApi = new TbdexHttpServer({ exchangesApi })
     const server = testApi.listen(8001)
 
-    const requestToken = await TbdexHttpClient.generateRequestToken(alice.keySet.verificationMethodKeys[0].privateKeyJwk, alice.document.verificationMethod[0].id)
+    const requestToken = await TbdexHttpClient.generateRequestToken(alice)
     const resp = await fetch('http://localhost:8001/exchanges', {
       headers: {
         'Authorization': `Bearer ${requestToken}`

--- a/packages/protocol/src/message.ts
+++ b/packages/protocol/src/message.ts
@@ -1,11 +1,11 @@
 import type { MessageKind, MessageKindModel, MessageModel, MessageMetadata, NewMessage } from './types.js'
 import type { Rfq, Quote, Order, OrderStatus, Close } from './message-kinds/index.js'
-import type { PrivateKeyJwk as Web5PrivateKeyJwk } from '@web5/crypto'
 import type { MessageKindClass } from './message-kinds/index.js'
 
 import { validate } from './validator.js'
 import { Crypto } from './crypto.js'
 import { typeid } from 'typeid-js'
+import { PortableDid } from '@web5/dids'
 
 
 /**
@@ -100,15 +100,13 @@ export abstract class Message<T extends MessageKind> {
 
   /**
    * signs the message as a jws with detached content and sets the signature property
-   * @param privateKeyJwk - the key to sign with
-   * @param kid - the verification method id to include in the jws header. used by the verifier to
-   *               select the appropriate verificationMethod when dereferencing the signer's DID
+   * @param did - the signer's DID
    */
-  async sign(privateKeyJwk: Web5PrivateKeyJwk, kid: string): Promise<void> {
+  async sign(did: PortableDid): Promise<void> {
     const payload = { metadata: this.metadata, data: this.data }
     const payloadDigest = Crypto.digest(payload)
 
-    this._signature = await Crypto.sign({ privateKeyJwk, kid, payload: payloadDigest, detached: true })
+    this._signature = await Crypto.sign({ did: did, payload: payloadDigest, detached: true })
   }
 
   /**

--- a/packages/protocol/src/resource.ts
+++ b/packages/protocol/src/resource.ts
@@ -1,10 +1,10 @@
 import type { ResourceModel, ResourceMetadata, ResourceKind, ResourceKindModel, NewResource } from './types.js'
-import type { PrivateKeyJwk as Web5PrivateKeyJwk } from '@web5/crypto'
 import type { ResourceKindClass } from './resource-kinds/index.js'
 
 import { typeid } from 'typeid-js'
 import { Crypto } from './crypto.js'
 import { validate } from './validator.js'
+import { PortableDid } from '@web5/dids'
 
 
 /**
@@ -94,15 +94,13 @@ export abstract class Resource<T extends ResourceKind> {
 
   /**
    * signs the message as a jws with detached content and sets the signature property
-   * @param privateKeyJwk - the key to sign with
-   * @param kid - the kid to include in the jws header. used by the verifier to select the appropriate verificationMethod
-   *              when dereferencing the signer's DID
+   * @param did - the signer's DID
    */
-  async sign(privateKeyJwk: Web5PrivateKeyJwk, kid: string): Promise<void> {
+  async sign(did: PortableDid): Promise<void> {
     const payload = { metadata: this.metadata, data: this.data }
     const payloadDigest = Crypto.digest(payload)
 
-    this._signature = await Crypto.sign({ privateKeyJwk, kid, payload: payloadDigest, detached: true })
+    this._signature = await Crypto.sign({ did, payload: payloadDigest, detached: true })
   }
 
   /**

--- a/packages/protocol/tests/crypto.spec.ts
+++ b/packages/protocol/tests/crypto.spec.ts
@@ -1,67 +1,38 @@
 import { expect } from 'chai'
 
 import { DevTools, Crypto } from '../src/main.js'
-import { utils as didUtils } from '@web5/dids'
 import { Convert } from '@web5/common'
 
 describe('Crypto', () => {
   describe('sign / verify', () => {
     it('works with did:ion', async () => {
       const alice = await DevTools.createDid('ion')
-      const [ verificationMethodKey ] = alice.keySet.verificationMethodKeys
-      const { privateKeyJwk } = verificationMethodKey
-
       const payload = { timestamp: new Date().toISOString() }
       const payloadBytes = Convert.object(payload).toUint8Array()
 
-      const token = await Crypto.sign({
-        privateKeyJwk,
-        kid      : `${alice.did}#${privateKeyJwk.kid}`,
-        payload  : payloadBytes,
-        detached : false
-      })
-
+      const token = await Crypto.sign({ did: alice, payload: payloadBytes, detached: false })
       await Crypto.verify({ signature: token })
-    })
+    }).timeout(30_000)
 
     it('works with did:key', async () => {
       const alice = await DevTools.createDid('key')
-      const [ verificationMethodKey ] = alice.keySet.verificationMethodKeys
-      const { privateKeyJwk } = verificationMethodKey
-
-      const parsedDid = didUtils.parseDid({ didUrl: alice.did })
-      const kid = `${alice.did}#${parsedDid.id}`
 
       const payload = { timestamp: new Date().toISOString() }
       const payloadBytes = Convert.object(payload).toUint8Array()
 
-      const token = await Crypto.sign({
-        privateKeyJwk,
-        kid,
-        payload  : payloadBytes,
-        detached : false
-      })
-
+      const token = await Crypto.sign({ did: alice, payload: payloadBytes, detached: false })
       await Crypto.verify({ signature: token })
     })
 
     it('works with detached content', async () => {
       const alice = await DevTools.createDid('ion')
-      const [ verificationMethodKey ] = alice.keySet.verificationMethodKeys
-      const { privateKeyJwk } = verificationMethodKey
-
       const payload = { timestamp: new Date().toISOString() }
       const payloadBytes = Convert.object(payload).toUint8Array()
 
-      const token = await Crypto.sign({
-        privateKeyJwk,
-        kid      : `${alice.did}#${privateKeyJwk.kid}`,
-        payload  : payloadBytes,
-        detached : true
-      })
+      const token = await Crypto.sign({ did: alice, payload: payloadBytes, detached: true })
 
       const did = await Crypto.verify({ signature: token, detachedPayload: payloadBytes })
       expect(alice.did).to.equal(did)
-    })
+    }).timeout(30_000)
   })
 })

--- a/packages/protocol/tests/offering.spec.ts
+++ b/packages/protocol/tests/offering.spec.ts
@@ -124,9 +124,8 @@ describe('Offering', () => {
         data     : offeringData
       })
 
-      const { privateKeyJwk } = pfi.keySet.verificationMethodKeys[0]
-      const kid = pfi.document.verificationMethod[0].id
-      await offering.sign(privateKeyJwk, kid)
+
+      await offering.sign(pfi)
 
       expect(offering.signature).to.not.be.undefined
       expect(typeof offering.signature).to.equal('string')
@@ -139,14 +138,13 @@ describe('Offering', () => {
         data     : offeringData
       })
 
-      const { privateKeyJwk } = pfi.keySet.verificationMethodKeys[0]
-      const kid = pfi.document.verificationMethod[0].id
-      await offering.sign(privateKeyJwk, kid)
+
+      await offering.sign(pfi)
 
       const [base64UrlEncodedJwsHeader] = offering.signature.split('.')
       const jwsHeader = Convert.base64Url(base64UrlEncodedJwsHeader).toObject()
 
-      expect(jwsHeader['kid']).to.equal(kid)
+      expect(jwsHeader['kid']).to.equal(pfi.document.verificationMethod[0].id)
       expect(jwsHeader['alg']).to.exist
     })
   })
@@ -159,10 +157,7 @@ describe('Offering', () => {
         data     : offeringData
       })
 
-      const { privateKeyJwk } = pfi.keySet.verificationMethodKeys[0]
-      const kid = pfi.document.verificationMethod[0].id
-      await offering.sign(privateKeyJwk, kid)
-
+      await offering.sign(pfi)
       await offering.verify()
     })
 
@@ -207,9 +202,7 @@ describe('Offering', () => {
         data     : offeringData
       })
 
-      const { privateKeyJwk } = pfi.keySet.verificationMethodKeys[0]
-      const kid = pfi.document.verificationMethod[0].id
-      await offering.sign(privateKeyJwk, kid)
+      await offering.sign(pfi)
 
       const jsonResource = JSON.stringify(offering)
       const parsedResource = await Offering.parse(jsonResource)

--- a/packages/protocol/tests/rfq.spec.ts
+++ b/packages/protocol/tests/rfq.spec.ts
@@ -66,51 +66,44 @@ describe('Rfq', () => {
 
   describe('sign', () => {
     it('sets signature property', async () => {
-      const alice = await DevTools.createDid()
+      const did = await DevTools.createDid()
       const rfq = Rfq.create({
-        metadata : { from: alice.did, to: 'did:ex:pfi' },
+        metadata : { from: did.did, to: 'did:ex:pfi' },
         data     : rfqData
       })
 
-      const { privateKeyJwk } = alice.keySet.verificationMethodKeys[0]
-      const kid = alice.document.verificationMethod[0].id
-      await rfq.sign(privateKeyJwk, kid)
+      await rfq.sign(did)
 
       expect(rfq.signature).to.not.be.undefined
       expect(typeof rfq.signature).to.equal('string')
     })
 
     it('includes alg and kid in jws header', async () => {
-      const alice = await DevTools.createDid()
+      const did = await DevTools.createDid()
       const rfq = Rfq.create({
-        metadata : { from: alice.did, to: 'did:ex:pfi' },
+        metadata : { from: did.did, to: 'did:ex:pfi' },
         data     : rfqData
       })
 
-      const { privateKeyJwk } = alice.keySet.verificationMethodKeys[0]
-      const kid = alice.document.verificationMethod[0].id
-      await rfq.sign(privateKeyJwk, kid)
+      await rfq.sign(did)
 
       const [base64UrlEncodedJwsHeader] = rfq.signature.split('.')
       const jwsHeader = Convert.base64Url(base64UrlEncodedJwsHeader).toObject()
 
-      expect(jwsHeader['kid']).to.equal(kid)
+      expect(jwsHeader['kid']).to.equal(did.document.verificationMethod[0].id)
       expect(jwsHeader['alg']).to.exist
     })
   })
 
   describe('verify', () => {
     it('does not throw an exception if message integrity is intact', async () => {
-      const alice = await DevTools.createDid()
+      const did = await DevTools.createDid()
       const rfq = Rfq.create({
-        metadata : { from: alice.did, to: 'did:ex:pfi' },
+        metadata : { from: did.did, to: 'did:ex:pfi' },
         data     : rfqData
       })
 
-      const { privateKeyJwk } = alice.keySet.verificationMethodKeys[0]
-      const kid = alice.document.verificationMethod[0].id
-      await rfq.sign(privateKeyJwk, kid)
-
+      await rfq.sign(did)
       await rfq.verify()
     })
 
@@ -149,15 +142,14 @@ describe('Rfq', () => {
     })
 
     it('returns an instance of Message if parsing is successful', async () => {
-      const alice = await DevTools.createDid()
+      const did = await DevTools.createDid()
       const rfq = Rfq.create({
-        metadata : { from: alice.did, to: 'did:ex:pfi' },
+        metadata : { from: did.did, to: 'did:ex:pfi' },
         data     : rfqData
       })
 
-      const { privateKeyJwk } = alice.keySet.verificationMethodKeys[0]
-      const kid = alice.document.verificationMethod[0].id
-      await rfq.sign(privateKeyJwk, kid)
+
+      await rfq.sign(did)
 
       const jsonMessage = JSON.stringify(rfq)
       const parsedMessage = await Rfq.parse(jsonMessage)
@@ -168,19 +160,19 @@ describe('Rfq', () => {
 
   describe('verifyClaims', () => {
     it(`does not throw an exception if an rfq's claims fulfill the provided offering's requirements`, async () => {
-      const alice = await DevTools.createDid()
+      const did = await DevTools.createDid()
       const offering = DevTools.createOffering()
       const { signedCredential } = await DevTools.createCredential({ // this credential fulfills the offering's required claims
         type    : 'SanctionsCredential',
-        issuer  : alice,
-        subject : alice.did,
+        issuer  : did,
+        subject : did.did,
         data    : {
           'beep': 'boop'
         }
       })
 
       const rfq = Rfq.create({
-        metadata : { from: alice.did, to: 'did:ex:pfi' },
+        metadata : { from: did.did, to: 'did:ex:pfi' },
         data     : {
           offeringId  : 'abcd123',
           payinMethod : {
@@ -207,19 +199,19 @@ describe('Rfq', () => {
     })
 
     it(`throws an exception if an rfq's claims dont fulfill the provided offering's requirements`, async () => {
-      const alice = await DevTools.createDid()
+      const did = await DevTools.createDid()
       const offering = DevTools.createOffering()
       const { signedCredential } = await DevTools.createCredential({
         type    : 'PuupuuCredential',
-        issuer  : alice,
-        subject : alice.did,
+        issuer  : did,
+        subject : did.did,
         data    : {
           'beep': 'boop'
         }
       })
 
       const rfq = Rfq.create({
-        metadata : { from: alice.did, to: 'did:ex:pfi' },
+        metadata : { from: did.did, to: 'did:ex:pfi' },
         data     : {
           offeringId  : 'abcd123',
           payinMethod : {


### PR DESCRIPTION
> [!IMPORTANT]
> This PR changes the Public API surface for both `@tbdex/http-client` and `@tbdex/protocol`

This PR introduces a change to the arguments passed to functions that sign things, namely:
* `Message.sign` (e.g. `rfq.sign`, `quote.sign` etc.)
* `Resource.sign` (e.g. `offering.sign`)

## API Change

### Before
```typescript
const did = await DidDhtMethod.create()
const rfq = Rfq.create({
  metadata : { from: did.did, to: 'did:ex:pfi' },
  data     : rfqData
})

const { privateKeyJwk } = did.keySet.verificationMethodKeys[0]
let verificationMethodId = `${did.did}#${did.document.verificationMethod[0].id}`

await rfq.sign(privateKeyJwk, verificationMethodId)
```

### After
```typescript
const did = await DidDhtMethod.create()
const rfq = Rfq.create({
  metadata : { from: did.did, to: 'did:ex:pfi' },
  data     : rfqData
})

await rfq.sign(did)
```

## Rationale
* The proposed change prevents the caller from having to think or know about `privateKeyJwk` or verification method ids
* Aligns with the approach `tbdex-kt` and `tbdex-rs` have taken
* Sets us up for the key management changes coming to `web5-js`