### PR TITLE
Add `sdk` package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@tbdex/protocol", "@tbdex/http-client", "@tbdex/http-server"]],
+  "fixed": [["@tbdex/protocol", "@tbdex/http-client", "@tbdex/http-server", "@tbdex/sdk"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        package: ["protocol", "http-client", "http-server"]
+        package: ["protocol", "http-client", "http-server", "sdk"]
 
     steps:
       - name: Checkout source

--- a/packages/protocol/src/crypto.ts
+++ b/packages/protocol/src/crypto.ts
@@ -17,7 +17,7 @@ import { PortableDid } from '@web5/dids'
  * Options passed to {@link Crypto.sign}
  * @beta
  */
-export type SignOptions = {
+export type TbdexSignOptions = {
   /** Indicates whether the payload is detached from the JWS. If `true`, the payload is not included in the resulting JWS. */
   detached: boolean,
   /** The payload to be signed. */
@@ -96,7 +96,7 @@ export class Crypto {
    * @returns A promise that resolves to the generated compact JWS.
    * @throws Will throw an error if the specified algorithm is not supported.
    */
-  static async sign(opts: SignOptions) {
+  static async sign(opts: TbdexSignOptions) {
     const { did, payload, detached } = opts
 
     const { privateKeyJwk } = did.keySet.verificationMethodKeys[0]

--- a/packages/protocol/src/did-resolver.ts
+++ b/packages/protocol/src/did-resolver.ts
@@ -7,7 +7,7 @@ import { DidResolver as Web5DidResolver, DidKeyMethod, DidIonMethod, DidDhtMetho
  *
  * @beta
  */
-export const DidResolver = new Web5DidResolver({
+const DidResolver = new Web5DidResolver({
   didResolvers: [DidIonMethod, DidKeyMethod, DidDhtMethod]
 })
 

--- a/packages/sdk/build/bundles.js
+++ b/packages/sdk/build/bundles.js
@@ -1,0 +1,16 @@
+import esbuild from 'esbuild';
+import browserConfig from './esbuild-browser-config.cjs';
+
+// esm polyfilled bundle for browser
+esbuild.build({
+  ...browserConfig,
+  outfile: 'dist/browser.mjs',
+});
+
+// iife polyfilled bundle for browser
+esbuild.build({
+  ...browserConfig,
+  format     : 'iife',
+  globalName : 'tbDEX',
+  outfile    : 'dist/browser.js',
+});

--- a/packages/sdk/build/esbuild-browser-config.cjs
+++ b/packages/sdk/build/esbuild-browser-config.cjs
@@ -1,0 +1,13 @@
+/** @type {import('esbuild').BuildOptions} */
+module.exports = {
+  entryPoints : ['./src/main.ts'],
+  bundle      : true,
+  format      : 'esm',
+  sourcemap   : true,
+  minify      : true,
+  platform    : 'browser',
+  target      : ['chrome101', 'firefox108', 'safari16'],
+  define      : {
+    'global': 'globalThis',
+  },
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@tbdex/sdk",
+  "version": "0.22.1",
+  "type": "module",
+  "description": "Library that includes type definitions for tbdex messages",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/TBD54566975/tbdex-js/tree/main/packages/sdk#readme",
+  "bugs": "https://github.com/TBD54566975/tbdex-js/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TBD54566975/tbdex-js",
+    "directory": "packages/sdk"
+  },
+  "contributors": [
+    {
+      "name": "Jiyoon Koo",
+      "url": "https://github.com/jiyoontbd"
+    },
+    {
+      "name": "Moe Jangda",
+      "url": "https://github.com/mistermoe"
+    },
+    {
+      "name": "Phoebe Lew",
+      "url": "https://github.com/phoebe-lew"
+    },
+    {
+      "name": "Ethan Lee",
+      "url": "https://github.com/ethan-tbd"
+    }
+  ],
+  "files": [
+    "dist",
+    "src"
+  ],
+  "main": "./dist/cjs/src/main.js",
+  "module": "./dist/esm/src/main.js",
+  "types": "./dist/types/src/main.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/src/main.js",
+      "require": "./dist/cjs/src/main.js",
+      "types": "./dist/types/src/main.d.ts"
+    },
+    "./browser": {
+      "import": "./dist/browser.mjs",
+      "require": "./dist/browser.js",
+      "types": "./dist/types/src/main.d.ts"
+    }
+  },
+  "dependencies": {
+    "@tbdex/http-client": "workspace:*",
+    "@web5/common": "0.2.1",
+    "@web5/credentials": "0.3.2",
+    "@web5/crypto": "0.2.2",
+    "@web5/dids": "0.2.2"
+  },
+  "devDependencies": {
+    "rimraf": "5.0.5",
+    "typescript": "5.2.2",
+    "esbuild": "0.16.17"
+  },
+  "scripts": {
+    "clean": "rimraf generated dist",
+    "build:esm": "rimraf dist/esm dist/types && tsc",
+    "build:cjs": "rimraf dist/cjs && tsc -p tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > ./dist/cjs/package.json",
+    "build:browser": "rimraf dist/browser.mjs dist/browser.js && node build/bundles.js",
+    "build": "pnpm clean && pnpm build:esm && pnpm build:cjs && pnpm build:browser",
+    "lint": "eslint . --ext .ts --max-warnings 0",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "docs": "pnpm build:esm && typedoc --plugin typedoc-plugin-markdown --out docs src/main.ts",
+    "try": "pnpm compile-validators && pnpm build:esm && node dist/esm/src/try.js"
+  }
+}

--- a/packages/sdk/src/main.ts
+++ b/packages/sdk/src/main.ts
@@ -1,0 +1,9 @@
+export * from '@web5/common'
+export { EcdsaAlgorithm, EdDsaAlgorithm, Ed25519, Secp256k1, Jose } from '@web5/crypto'
+export * from '@web5/dids'
+
+export type { PresentationDefinitionV2, PresentationExchange, VcDataModel, VerifiableCredentialCreateOptions, SignOptions } from '@web5/credentials'
+export { VerifiableCredential } from '@web5/credentials'
+
+
+export * from '@tbdex/http-client'

--- a/packages/sdk/tsconfig.cjs.json
+++ b/packages/sdk/tsconfig.cjs.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": [
+      "DOM",
+      "ES2015",
+    ],
+    "target": "ES5",
+    "outDir": "dist/cjs",
+    "declaration": false,
+    "declarationMap": false,
+    "declarationDir": null
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/try.ts"
+  ]
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "strict": false,
+    "lib": [
+      "DOM",
+      "ES6"
+    ],
+    "rootDir": "./",
+    "allowJs": true,
+    "target": "esnext",
+    "module": "nodenext",
+    "outDir": "dist/esm",
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "dist/types",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "build",
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,34 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/sdk:
+    dependencies:
+      '@tbdex/http-client':
+        specifier: workspace:*
+        version: link:../http-client
+      '@web5/common':
+        specifier: 0.2.1
+        version: 0.2.1
+      '@web5/credentials':
+        specifier: 0.3.2
+        version: 0.3.2
+      '@web5/crypto':
+        specifier: 0.2.2
+        version: 0.2.2
+      '@web5/dids':
+        specifier: 0.2.2
+        version: 0.2.2
+    devDependencies:
+      esbuild:
+        specifier: 0.16.17
+        version: 0.16.17
+      rimraf:
+        specifier: 5.0.5
+        version: 5.0.5
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
 packages:
 
   /@aashutoshrathi/word-wrap@1.2.6:
@@ -3245,6 +3273,18 @@ packages:
       is-glob: 4.0.3
     dev: true
 
+  /glob@10.3.10:
+    resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 2.3.6
+      minimatch: 9.0.3
+      minipass: 7.0.3
+      path-scurry: 1.10.1
+    dev: true
+
   /glob@10.3.4:
     resolution: {integrity: sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3746,6 +3786,15 @@ packages:
 
   /jackspeak@2.3.3:
     resolution: {integrity: sha512-R2bUw+kVZFS/h1AZqBKrSgDmdmjApzgY0AlCPumopFiAlbUxE2gf+SCuBzQ0cP5hHmUmFYF5yw55T97Th5Kstg==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+    dev: true
+
+  /jackspeak@2.3.6:
+    resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -5083,6 +5132,14 @@ packages:
     hasBin: true
     dependencies:
       glob: 10.3.4
+    dev: true
+
+  /rimraf@5.0.5:
+    resolution: {integrity: sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      glob: 10.3.10
     dev: true
 
   /ripemd160@2.0.2:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - 'packages/protocol'
   - 'packages/http-client'
   - 'packages/http-server'
+  - 'packages/sdk'


### PR DESCRIPTION
# Summary
This PR adds an additional package `@tbdex/sdk` that is a rollup of all the packages needed to:
* encode/decode
* create crypto keys, sign, verify
* create & resolve DIDs
* create & verify Verifiable Credentials

# Rationale
More often than not, when doing tbdex related things from the client, we end up with the following dependencies:

```json
{
  "type": "module",
  "dependencies": {
    "@web5/dids": "0.2.2",
    "@web5/crypto": "0.2.3",
    "@web5/common": "0.2.1",
    "@tbdex/http-client": "0.22.1"
  }
}
```

being able to collapse that into:

```json
{
  "type": "module",
  "dependencies": {
    "@tbdex/sdk": "0.22.1"
  }
}
```

will prevent folks from having to dig up all the necessary dependencies needed to do all the things.

# Notes
I would have liked to `export *` all of the packages in `sdk/main.ts` but was unable to because of collisions e.g. 
* `DidResolver` exported from both `@tbdex/protocol` and `@web5/dids`
* `utils` exported from `@web5/dids`, `@web5/credentials`, and `@web5/crypto`