### PR TITLE
Fix npm publish trigger

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,10 @@
 name: Publish Packages to NPM and TBDocs
 
 on:
-  release:
-    types: [created]
+  workflow_run:
+    workflows: ["Create GH Release"]
+    types:
+      - completed
   workflow_dispatch:
 
 # Allow only one concurrent deployment,but do NOT cancel in-progress runs as
@@ -19,6 +21,8 @@ jobs:
   publish-npm:
     name: NPM Publish
     runs-on: ubuntu-latest
+    # only runs if workflow_run is completed successfully or manually workflow dispatch
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
 
     strategy:
       max-parallel: 1

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Packages to NPM and TBDocs
+name: Publish Packages to NPM
 
 on:
   workflow_run:


### PR DESCRIPTION
the current release workflow is not triggering the npm publish... this PR fixes it.

Reason from [GH Docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow):

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

And I was trying to trigger the `on: release`. Now I fixed the npm publish to be triggered when the new automated GH release is completed successfully instead!