### PR TITLE
adding default typescript version to align on

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-* @michaelneale @mistermoe @jiyoontbd @phoebe-lew @KendallWeihe @diehuxx
+* @michaelneale @mistermoe @jiyoontbd @phoebe-lew @KendallWeihe @kirahsapong @diehuxx
 
 
 # -----------------------------------------------

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/chai": "4.3.5",
     "@types/eslint": "8.44.2",
     "@types/mocha": "10.0.1",
+    "typescript": "5.2.2",
     "@typescript-eslint/eslint-plugin": "6.7.0",
     "@typescript-eslint/parser": "6.7.0",
     "eslint": "8.49.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       semver:
         specifier: 7.5.4
         version: 7.5.4
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
 
   packages/http-client:
     dependencies:


### PR DESCRIPTION
# Summary

Aligning on typescript version to be at `5.2.2` for VS Code `settings.json` and top level `package.json`

Part of an effort to break apart [this PR](https://github.com/TBD54566975/tbdex-js/pull/126) into smaller ones. Related to #122 
