### PR TITLE
bumping web5 versions

### DIFF
--- a/.changeset/real-schools-enjoy.md
+++ b/.changeset/real-schools-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@tbdex/http-client": minor
+"@tbdex/protocol": minor
+---
+
+Upgrading web5 versions in protocol and http-client

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -50,17 +50,21 @@
   },
   "dependencies": {
     "@tbdex/protocol": "workspace:*",
-    "@web5/common": "0.2.1",
-    "@web5/crypto": "0.2.2",
-    "@web5/dids": "0.2.2",
-    "query-string": "8.1.0"
+    "@web5/common": "0.2.2",
+    "@web5/credentials": "0.4.1",
+    "@web5/crypto": "0.2.4",
+    "@web5/dids": "0.2.4",
+    "ms": "2.1.3",
+    "query-string": "8.1.0",
+    "typeid-js": "0.3.0"
   },
   "devDependencies": {
     "@playwright/test": "1.34.3",
     "@types/chai": "4.3.5",
     "@types/eslint": "8.37.0",
     "@types/mocha": "10.0.1",
-    "@types/sinon": "^17.0.2",
+    "@types/ms": "0.7.34",
+    "@types/sinon": "17.0.2",
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",
     "chai": "4.3.10",
@@ -78,7 +82,7 @@
     "mkdirp": "3.0.1",
     "mocha": "10.2.0",
     "rimraf": "4.4.0",
-    "sinon": "15.0.2",
+    "sinon": "17.0.1",
     "typedoc": "0.25.0",
     "typedoc-plugin-markdown": "3.16.0",
     "typescript": "5.2.2"

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -64,7 +64,7 @@
     "@types/eslint": "8.37.0",
     "@types/mocha": "10.0.1",
     "@types/ms": "0.7.34",
-    "@types/sinon": "17.0.2",
+    "@types/sinon": "17.0.1",
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",
     "chai": "4.3.10",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -50,10 +50,10 @@
   },
   "dependencies": {
     "@noble/hashes": "1.3.2",
-    "@web5/common": "0.2.1",
-    "@web5/credentials": "0.3.2",
-    "@web5/crypto": "0.2.2",
-    "@web5/dids": "0.2.2",
+    "@web5/common": "0.2.2",
+    "@web5/credentials": "0.4.1",
+    "@web5/crypto": "0.2.4",
+    "@web5/dids": "0.2.4",
     "ajv": "8.12.0",
     "bignumber.js": "^9.1.2",
     "canonicalize": "2.0.0",
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.34.3",
+    "@types/sinon": "17.0.2",
     "chai": "4.3.10",
     "esbuild": "0.16.17",
     "karma": "6.4.1",
@@ -75,7 +76,7 @@
     "mocha": "10.2.0",
     "node-stdlib-browser": "1.2.0",
     "rimraf": "4.4.0",
-    "sinon": "15.0.2",
+    "sinon": "17.0.1",
     "typedoc": "0.25.0",
     "typedoc-plugin-markdown": "3.16.0",
     "typescript": "5.2.2"

--- a/packages/protocol/src/crypto.ts
+++ b/packages/protocol/src/crypto.ts
@@ -13,10 +13,10 @@ import type {
 import { sha256 } from '@noble/hashes/sha256'
 import { Convert } from '@web5/common'
 import { EcdsaAlgorithm, EdDsaAlgorithm } from '@web5/crypto'
-import { deferenceDidUrl, isVerificationMethod } from './did-resolver.js'
+import { isVerificationMethod } from './did-resolver.js'
 
 import canonicalize from 'canonicalize'
-import { PortableDid } from '@web5/dids'
+import { DidDhtMethod, DidIonMethod, DidKeyMethod, DidResolver, PortableDid, VerificationMethod } from '@web5/dids'
 
 /**
  * Options passed to {@link Crypto.sign}
@@ -171,8 +171,10 @@ export class Crypto {
       throw new Error('Signature verification failed: Expected JWS header to contain alg and kid')
     }
 
-    const verificationMethod = await deferenceDidUrl(jwsHeader.kid)
+    const didResolver = new DidResolver({ didResolvers: [DidKeyMethod, DidIonMethod, DidDhtMethod] })
+    const dereferenceResult = await didResolver.dereference({ didUrl: jwsHeader.kid })
 
+    const verificationMethod = dereferenceResult.contentStream as VerificationMethod
     if (!isVerificationMethod(verificationMethod)) { // ensure that appropriate verification method was found
       throw new Error('Signature verification failed: Expected kid in JWS header to dereference to a DID Document Verification Method')
     }

--- a/packages/protocol/src/crypto.ts
+++ b/packages/protocol/src/crypto.ts
@@ -1,15 +1,16 @@
 import type {
-  PrivateKeyJwk as Web5PrivateKeyJwk,
   CryptoAlgorithm,
   Web5Crypto,
   JwsHeaderParams,
-  PrivateKeyJwk,
-  PublicKeyJwk
+  JwkParamsEcPrivate,
+  JwkParamsOkpPrivate,
+  JwkParamsEcPublic,
+  JwkParamsOkpPublic
 } from '@web5/crypto'
 
 import { sha256 } from '@noble/hashes/sha256'
 import { Convert } from '@web5/common'
-import { EcdsaAlgorithm, EdDsaAlgorithm, Jose } from '@web5/crypto'
+import { EcdsaAlgorithm, EdDsaAlgorithm } from '@web5/crypto'
 import { deferenceDidUrl, isVerificationMethod } from './did-resolver.js'
 
 import canonicalize from 'canonicalize'
@@ -44,14 +45,14 @@ export type VerifyOptions = {
  */
 type SignerValue<T extends Web5Crypto.Algorithm> = {
   signer: CryptoAlgorithm,
-  options: T,
+  options?: T,
   alg: JwsHeader['alg'],
   crv: JsonWebKey['crv']
 }
 
 const secp256k1Signer: SignerValue<Web5Crypto.EcdsaOptions> = {
   signer  : new EcdsaAlgorithm(),
-  options : { name: 'ECDSA', hash: 'SHA-256' },
+  options : { name: 'ECDSA' },
   alg     : 'ES256K',
   crv     : 'secp256k1'
 }
@@ -101,32 +102,30 @@ export class Crypto {
   static async sign(opts: SignOptions) {
     const { did, payload, detached } = opts
 
-    const privateKeyJwk = did.keySet.verificationMethodKeys?.[0]?.privateKeyJwk
+    const privateKeyJwk = did.keySet.verificationMethodKeys[0].privateKeyJwk as JwkParamsEcPrivate | JwkParamsOkpPrivate
 
-    const algorithmName = privateKeyJwk?.['alg'] || ''
-    let namedCurve = Crypto.extractNamedCurve(privateKeyJwk)
+    const algorithmName = privateKeyJwk['alg'] || ''
+    const namedCurve = privateKeyJwk['crv'] || ''
     const algorithmId = `${algorithmName}:${namedCurve}`
 
     const algorithm = this.algorithms[algorithmId]
     if (!algorithm) {
-      throw new Error(`Algorithm (${algorithmId}) not supported`)
+      throw new Error(`${algorithmId} not supported`)
     }
 
-    let verificationMethodId = did.document.verificationMethod?.[0]?.id || ''
+    let verificationMethodId = did.document.verificationMethod[0].id
     if (verificationMethodId.startsWith('#')) {
-      verificationMethodId = `${did.did}#${verificationMethodId}`
+      verificationMethodId = `${did.did}${verificationMethodId}`
     }
 
     const jwsHeader: JwsHeader = { alg: algorithm.alg, kid: verificationMethodId }
     const base64UrlEncodedJwsHeader = Convert.object(jwsHeader).toBase64Url()
     const base64urlEncodedJwsPayload = Convert.uint8Array(payload).toBase64Url()
 
-    const key = await Jose.jwkToCryptoKey({ key: privateKeyJwk as Web5PrivateKeyJwk })
-
     const toSign = `${base64UrlEncodedJwsHeader}.${base64urlEncodedJwsPayload}`
     const toSignBytes = Convert.string(toSign).toUint8Array()
 
-    const signatureBytes = await algorithm.signer.sign({ key, data: toSignBytes, algorithm: algorithm.options })
+    const signatureBytes = await algorithm.signer.sign({ key: privateKeyJwk, data: toSignBytes, algorithm: algorithm.options })
     const base64UrlEncodedSignature = Convert.uint8Array(signatureBytes).toBase64Url()
 
     if (detached) {
@@ -170,13 +169,14 @@ export class Crypto {
       throw new Error('Signature verification failed: Expected JWS header to contain alg and kid')
     }
 
-    const verificationMethod = await deferenceDidUrl(jwsHeader.kid)
+    const verificationMethod = await deferenceDidUrl(jwsHeader.kid as string)
     if (!isVerificationMethod(verificationMethod)) { // ensure that appropriate verification method was found
       throw new Error('Signature verification failed: Expected kid in JWS header to dereference to a DID Document Verification Method')
     }
 
     // will be used to verify signature
-    const { publicKeyJwk } = verificationMethod
+    const publicKeyJwk = verificationMethod.publicKeyJwk as JwkParamsEcPublic | JwkParamsOkpPublic
+
     if (!publicKeyJwk) { // ensure that Verification Method includes public key as a JWK.
       throw new Error('Signature verification failed: Expected kid in JWS header to dereference to a DID Document Verification Method with publicKeyJwk')
     }
@@ -186,36 +186,18 @@ export class Crypto {
 
     const signatureBytes = Convert.base64Url(base64UrlEncodedSignature).toUint8Array()
 
-    const algorithmId = `${jwsHeader['alg']}:${Crypto.extractNamedCurve(publicKeyJwk)}`
+    const algorithmId = `${jwsHeader['alg']}:${publicKeyJwk['crv']}`
     const { signer, options } = Crypto.algorithms[algorithmId]
 
-    // TODO: remove this monkeypatch once 'ext' is no longer a required property within a jwk passed to `jwkToCryptoKey`
-    const monkeyPatchPublicKeyJwk = {
-      ...publicKeyJwk,
-      ext     : 'true' as const,
-      key_ops : ['verify']
-    }
 
-    const key = await Jose.jwkToCryptoKey({ key: monkeyPatchPublicKeyJwk })
-    const isLegit = await signer.verify({ algorithm: options, key, data: signedDataBytes, signature: signatureBytes })
+    const isLegit = await signer.verify({ algorithm: options, key: publicKeyJwk, data: signedDataBytes, signature: signatureBytes })
 
     if (!isLegit) {
       throw new Error('Signature verification failed: Integrity mismatch')
     }
 
-    const [did] = jwsHeader.kid.split('#')
+    const [did] = (jwsHeader as JwsHeaderParams).kid.split('#')
     return did
-  }
-
-  /**
-   * Gets crv property from a PublicKeyJwk or PrivateKeyJwk. Returns empty string if crv is undefined.
-   */
-  static extractNamedCurve(jwk: PrivateKeyJwk | PublicKeyJwk | undefined): string {
-    if (jwk && 'crv' in jwk) {
-      return jwk.crv
-    } else {
-      return ''
-    }
   }
 }
 

--- a/packages/protocol/src/crypto.ts
+++ b/packages/protocol/src/crypto.ts
@@ -13,10 +13,10 @@ import type {
 import { sha256 } from '@noble/hashes/sha256'
 import { Convert } from '@web5/common'
 import { EcdsaAlgorithm, EdDsaAlgorithm } from '@web5/crypto'
-import { isVerificationMethod } from './did-resolver.js'
+import { DidResolver, isVerificationMethod } from './did-resolver.js'
 
 import canonicalize from 'canonicalize'
-import { DidDhtMethod, DidIonMethod, DidKeyMethod, DidResolver, PortableDid, VerificationMethod } from '@web5/dids'
+import { PortableDid, VerificationMethod } from '@web5/dids'
 
 /**
  * Options passed to {@link Crypto.sign}
@@ -171,8 +171,7 @@ export class Crypto {
       throw new Error('Signature verification failed: Expected JWS header to contain alg and kid')
     }
 
-    const didResolver = new DidResolver({ didResolvers: [DidKeyMethod, DidIonMethod, DidDhtMethod] })
-    const dereferenceResult = await didResolver.dereference({ didUrl: jwsHeader.kid })
+    const dereferenceResult = await DidResolver.dereference({ didUrl: jwsHeader.kid })
 
     const verificationMethod = dereferenceResult.contentStream as VerificationMethod
     if (!isVerificationMethod(verificationMethod)) { // ensure that appropriate verification method was found

--- a/packages/protocol/src/dev-tools.ts
+++ b/packages/protocol/src/dev-tools.ts
@@ -1,7 +1,7 @@
 
 import type { OfferingData, QuoteData, RfqData } from './types.js'
 import type { PortableDid } from '@web5/dids'
-import { DidIonMethod, DidKeyMethod } from '@web5/dids'
+import { DidDhtMethod, DidIonMethod, DidKeyMethod } from '@web5/dids'
 import { VerifiableCredential } from '@web5/credentials'
 import { Offering } from './resource-kinds/index.js'
 import { Rfq } from './message-kinds/index.js'
@@ -65,9 +65,11 @@ export class DevTools {
    */
   static async createDid(didMethod: DidMethodOptions = 'key') {
     if (didMethod === 'key') {
-      return DidKeyMethod.create()
+      return await DidKeyMethod.create()
     } else if (didMethod === 'ion') {
-      return DidIonMethod.create()
+      return await DidIonMethod.create()
+    } else if (didMethod === 'dht') {
+      return await DidDhtMethod.create()
     } else {
       throw new Error(`${didMethod} method not implemented.`)
     }

--- a/packages/protocol/src/did-resolver.ts
+++ b/packages/protocol/src/did-resolver.ts
@@ -1,6 +1,6 @@
 import type { DidDocument, DidService, VerificationMethod } from '@web5/dids'
 
-import { DidResolver as Web5DidResolver, DidKeyMethod, DidIonMethod, DidDhtMethod, utils as didUtils } from '@web5/dids'
+import { DidResolver as Web5DidResolver, DidKeyMethod, DidIonMethod, DidDhtMethod } from '@web5/dids'
 
 /**
  * Can be used to resolve did:ion and did:key DIDs
@@ -35,52 +35,6 @@ export async function resolveDid(did: string): Promise<DidDocument> {
  * @beta
  */
 export type DidResource = DidDocument | VerificationMethod | DidService
-
-// TODO https://github.com/TBD54566975/tbdex-js/issues/147 Remove deferenceDidUrl with web5/dids DidResolver#dereference
-/**
- * Dereferences a DID URL according to [specification](https://www.w3.org/TR/did-core/#did-url-dereferencing).
- * See also: [DID URL Syntax](https://www.w3.org/TR/did-core/#did-url-syntax)
- *
- * **Note**: Support is limited to did#fragment within [Verification Method](https://www.w3.org/TR/did-core/#verification-methods)
- * and [Service](https://www.w3.org/TR/did-core/#services) only
- * @param didUrl - the did url to dereference
- * @returns the dereferenced resource
- * @throws if DID URL cannot be parsed
- * @throws if DID cannot be resolved
- * @beta
- */
-export async function deferenceDidUrl(didUrl: string): Promise<DidResource | undefined> {
-  const parsedDid = didUtils.parseDid({ didUrl })
-  if (!parsedDid) {
-    throw new Error('failed to parse did')
-  }
-
-  const didDocument = await resolveDid(didUrl)
-
-  // return the entire DID Document if no fragment is present on the did url
-  if (!parsedDid.fragment) {
-    return didDocument
-  }
-
-  const { service, verificationMethod } = didDocument
-
-  // create a set of possible id matches. the DID spec allows for an id to be the entire did#fragment or just #fragment.
-  // See: https://www.w3.org/TR/did-core/#relative-did-urls
-  // using a set for fast string comparison. DIDs can be lonnng.
-  const idSet = new Set([didUrl, parsedDid.fragment, `#${parsedDid.fragment}`])
-
-  for (let vm of verificationMethod || []) {
-    if (idSet.has(vm.id)) {
-      return vm
-    }
-  }
-
-  for (let svc of service || []) {
-    if (idSet.has(svc.id)) {
-      return svc
-    }
-  }
-}
 
 /**
  * type guard for {@link @web5/dids#VerificationMethod}

--- a/packages/protocol/src/did-resolver.ts
+++ b/packages/protocol/src/did-resolver.ts
@@ -42,6 +42,6 @@ export type DidResource = DidDocument | VerificationMethod | DidService
  * @returns true if the didResource is a `VerificationMethod`
  * @beta
  */
-export function isVerificationMethod(didResource: DidResource | undefined): didResource is VerificationMethod {
+export function isVerificationMethod(didResource: DidResource | null): didResource is VerificationMethod {
   return !!didResource && 'id' in didResource && 'type' in didResource && 'controller' in didResource
 }

--- a/packages/protocol/src/message-kinds/rfq.ts
+++ b/packages/protocol/src/message-kinds/rfq.ts
@@ -12,7 +12,7 @@ import Ajv from 'ajv'
  */
 export type CreateRfqOptions = {
   data: MessageKindModel<'rfq'>
-  metadata: Omit<MessageMetadata<'rfq'>, 'id' |'kind' | 'createdAt' | 'exchangeId'>
+  metadata: Omit<MessageMetadata<'rfq'>, 'id' | 'kind' | 'createdAt' | 'exchangeId'>
   private?: Record<string, any>
 }
 
@@ -61,7 +61,7 @@ export class Rfq extends Message<'rfq'> {
    * @throws if {@link Rfq.payoutMethod} property `paymentDetails` cannot be validated against the provided offering's payoutMethod requiredPaymentDetails
    */
   async verifyOfferingRequirements(offering: Offering | ResourceModel<'offering'>) {
-    if (offering.metadata.id !== this.offeringId)  {
+    if (offering.metadata.id !== this.offeringId) {
       throw new Error(`offering id mismatch. (rfq) ${this.offeringId} !== ${offering.metadata.id} (offering)`)
     }
 
@@ -146,14 +146,14 @@ export class Rfq extends Message<'rfq'> {
       return
     }
 
-    const credentials = PresentationExchange.selectCredentials(this.claims, offering.data.requiredClaims)
+    const credentials = PresentationExchange.selectCredentials({ vcJwts: this.claims, presentationDefinition: offering.data.requiredClaims })
 
     if (!credentials.length) {
       throw new Error(`claims do not fulfill the offering's requirements`)
     }
 
     for (let credential of credentials) {
-      await VerifiableCredential.verify(credential)
+      await VerifiableCredential.verify({ vcJwt: credential })
     }
   }
 

--- a/packages/protocol/src/resource-kinds/offering.ts
+++ b/packages/protocol/src/resource-kinds/offering.ts
@@ -1,6 +1,5 @@
 import type { ResourceKindModel, ResourceMetadata } from '../types.js'
 import { Resource } from '../resource.js'
-import type { PresentationDefinitionV2 } from '@web5/credentials'
 
 /**
  * Options passed to {@link Offering.create}
@@ -66,9 +65,7 @@ export class Offering extends Resource<'offering'> {
   }
 
   /** Articulates the claim(s) required when submitting an RFQ for this offering. */
-  // TODO: Remove type annotation once type alias replaced with direct export in @web5/credentials
-  // [Link to the PR](https://github.com/TBD54566975/web5-js/pull/336)
-  get requiredClaims(): PresentationDefinitionV2 | undefined {
+  get requiredClaims() {
     return this.data.requiredClaims
   }
 }

--- a/packages/protocol/tests/crypto.spec.ts
+++ b/packages/protocol/tests/crypto.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from 'chai'
 
-import { DevTools, Crypto } from '../src/main.js'
+import { DidIonMethod, DidKeyMethod } from '@web5/dids'
 import { Convert } from '@web5/common'
+import { Crypto } from '../src/main.js'
 
 describe('Crypto', () => {
   describe('sign / verify', () => {
     it('works with did:ion', async () => {
-      const alice = await DevTools.createDid('ion')
+      const alice = await DidIonMethod.create()
       const payload = { timestamp: new Date().toISOString() }
       const payloadBytes = Convert.object(payload).toUint8Array()
 
@@ -15,7 +16,7 @@ describe('Crypto', () => {
     }).timeout(30_000)
 
     it('works with did:key', async () => {
-      const alice = await DevTools.createDid('key')
+      const alice = await DidKeyMethod.create()
 
       const payload = { timestamp: new Date().toISOString() }
       const payloadBytes = Convert.object(payload).toUint8Array()
@@ -25,7 +26,7 @@ describe('Crypto', () => {
     })
 
     it('works with detached content', async () => {
-      const alice = await DevTools.createDid('ion')
+      const alice = await DidIonMethod.create()
       const payload = { timestamp: new Date().toISOString() }
       const payloadBytes = Convert.object(payload).toUint8Array()
 

--- a/packages/protocol/tests/crypto.spec.ts
+++ b/packages/protocol/tests/crypto.spec.ts
@@ -1,13 +1,12 @@
 import { expect } from 'chai'
 
-import { DidIonMethod, DidKeyMethod } from '@web5/dids'
 import { Convert } from '@web5/common'
-import { Crypto } from '../src/main.js'
+import { Crypto, DevTools } from '../src/main.js'
 
 describe('Crypto', () => {
   describe('sign / verify', () => {
     it('works with did:ion', async () => {
-      const alice = await DidIonMethod.create()
+      const alice = await DevTools.createDid('ion')
       const payload = { timestamp: new Date().toISOString() }
       const payloadBytes = Convert.object(payload).toUint8Array()
 
@@ -16,7 +15,7 @@ describe('Crypto', () => {
     }).timeout(30_000)
 
     it('works with did:key', async () => {
-      const alice = await DidKeyMethod.create()
+      const alice = await DevTools.createDid('key')
 
       const payload = { timestamp: new Date().toISOString() }
       const payloadBytes = Convert.object(payload).toUint8Array()
@@ -26,7 +25,7 @@ describe('Crypto', () => {
     })
 
     it('works with detached content', async () => {
-      const alice = await DidIonMethod.create()
+      const alice = await DevTools.createDid('ion')
       const payload = { timestamp: new Date().toISOString() }
       const payloadBytes = Convert.object(payload).toUint8Array()
 

--- a/packages/protocol/tests/rfq.spec.ts
+++ b/packages/protocol/tests/rfq.spec.ts
@@ -1,16 +1,39 @@
-import type { CreateRfqOptions, Offering } from '../src/main.js'
+import type { CreateRfqOptions, OfferingData, RfqData } from '../src/main.js'
 
-import { Rfq, DevTools } from '../src/main.js'
+import { VerifiableCredential } from '@web5/credentials'
+import { DidKeyMethod } from '@web5/dids'
+import { Rfq, Offering } from '../src/main.js'
 import { Convert } from '@web5/common'
 import { expect } from 'chai'
+
+const rfqData: RfqData = {
+  offeringId  : 'abcd123',
+  payinMethod : {
+    kind           : 'DEBIT_CARD',
+    paymentDetails : {
+      'cardNumber'     : '1234567890123456',
+      'expiryDate'     : '12/22',
+      'cardHolderName' : 'Ephraim Bartholomew Winthrop',
+      'cvv'            : '123'
+    }
+  },
+  payoutMethod: {
+    kind           : 'BTC_ADDRESS',
+    paymentDetails : {
+      btcAddress: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+    }
+  },
+  payinAmount : '20000.00',
+  claims      : ['']
+}
 
 describe('Rfq', () => {
   describe('create', () => {
     it('creates an rfq', async () => {
-      const alice = await DevTools.createDid()
+      const alice = await DidKeyMethod.create()
       const message = Rfq.create({
         metadata : { from: alice.did, to: 'did:ex:pfi' },
-        data     : await DevTools.createRfqData()
+        data     : rfqData
       })
 
       expect(message.id).to.exist
@@ -45,10 +68,10 @@ describe('Rfq', () => {
 
   describe('sign', () => {
     it('sets signature property', async () => {
-      const did = await DevTools.createDid()
+      const did = await DidKeyMethod.create()
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : await DevTools.createRfqData()
+        data     : rfqData
       })
 
       await rfq.sign(did)
@@ -58,28 +81,28 @@ describe('Rfq', () => {
     })
 
     it('includes alg and kid in jws header', async () => {
-      const did = await DevTools.createDid()
+      const did = await DidKeyMethod.create()
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : await DevTools.createRfqData()
+        data     : rfqData
       })
 
       await rfq.sign(did)
 
-      const [base64UrlEncodedJwsHeader] = rfq.signature!.split('.')
-      const jwsHeader: { kid?: string, alg?: string}  = Convert.base64Url(base64UrlEncodedJwsHeader).toObject()
+      const [base64UrlEncodedJwsHeader] = rfq.signature.split('.')
+      const jwsHeader = Convert.base64Url(base64UrlEncodedJwsHeader).toObject()
 
-      expect(jwsHeader['kid']).to.equal(did.document.verificationMethod![0].id)
+      expect(jwsHeader['kid']).to.equal(did.document.verificationMethod[0].id)
       expect(jwsHeader['alg']).to.exist
     })
   })
 
   describe('verify', () => {
     it('does not throw an exception if message integrity is intact', async () => {
-      const did = await DevTools.createDid()
+      const did = await DidKeyMethod.create()
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : await DevTools.createRfqData()
+        data     : rfqData
       })
 
       await rfq.sign(did)
@@ -87,10 +110,10 @@ describe('Rfq', () => {
     })
 
     it('throws an error if no signature is present on the message provided', async () => {
-      const alice = await DevTools.createDid()
+      const alice = await DidKeyMethod.create()
       const rfq = Rfq.create({
         metadata : { from: alice.did, to: 'did:ex:pfi' },
-        data     : await DevTools.createRfqData()
+        data     : rfqData
       })
 
       try {
@@ -121,10 +144,10 @@ describe('Rfq', () => {
     })
 
     it('returns an instance of Message if parsing is successful', async () => {
-      const did = await DevTools.createDid()
+      const did = await DidKeyMethod.create()
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : await DevTools.createRfqData()
+        data     : rfqData
       })
 
       await rfq.sign(did)
@@ -136,35 +159,33 @@ describe('Rfq', () => {
     })
   })
 
-  describe('verifyOfferingRequirements', async () => {
-    let offering: Offering
-    let rfqOptions: CreateRfqOptions
-
-    beforeEach(async () => {
-      const did = await DevTools.createDid()
-      const { signedCredential } = await DevTools.createCredential({ // this credential fulfills the offering's required claims
+  describe('verifyOfferingRequirements', () => {
+    const offering: Offering = createUnsignedOffering()
+    const rfqOptions: CreateRfqOptions = {
+      metadata: {
+        from : '',
+        to   : 'did:ex:pfi'
+      },
+      data: {
+        ...rfqData,
+        offeringId: offering.id,
+      }
+    }
+    before(async () => {
+      const did = await DidKeyMethod.create()
+      const vc = await VerifiableCredential.create({
         type    : 'SanctionsCredential',
-        issuer  : did,
+        issuer  : did.did,
         subject : did.did,
         data    : {
           'beep': 'boop'
         }
       })
 
-      offering = DevTools.createOffering()
+      const vcJwt = await vc.sign({ did })
 
-      rfqOptions = {
-        metadata: {
-          from : '',
-          to   : 'did:ex:pfi'
-        },
-        data: {
-          ...await DevTools.createRfqData(),
-          offeringId: offering.id,
-        }
-      }
       rfqOptions.metadata.from = did.did
-      rfqOptions.data.claims = [signedCredential]
+      rfqOptions.data.claims = [vcJwt]
     })
 
     it('throws an error if offeringId doesn\'t match the provided offering\'s id', async () => {
@@ -184,6 +205,7 @@ describe('Rfq', () => {
     })
 
     it('throws an error if payinAmount exceeds the provided offering\'s maxAmount', async () => {
+      const offering = createUnsignedOffering()
       offering.payinCurrency.maxAmount = '0.01'
 
       const rfq = Rfq.create({
@@ -285,46 +307,84 @@ describe('Rfq', () => {
 
   describe('verifyClaims', () => {
     it(`does not throw an exception if an rfq's claims fulfill the provided offering's requirements`, async () => {
-      const did = await DevTools.createDid()
-      const offering = DevTools.createOffering()
-      const { signedCredential } = await DevTools.createCredential({ // this credential fulfills the offering's required claims
+      const did = await DidKeyMethod.create()
+      const offering = createUnsignedOffering()
+
+      const vc = await VerifiableCredential.create({
         type    : 'SanctionsCredential',
-        issuer  : did,
+        issuer  : did.did,
         subject : did.did,
         data    : {
           'beep': 'boop'
         }
       })
 
-      const rfqData = await DevTools.createRfqData()
-      rfqData.claims = [signedCredential]
+      const vcJwt = await vc.sign({ did })
 
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : rfqData
+        data     : {
+          offeringId  : 'abcd123',
+          payinMethod : {
+            kind           : 'DEBIT_CARD',
+            paymentDetails : {
+              'cardNumber'     : '1234567890123456',
+              'expiryDate'     : '12/22',
+              'cardHolderName' : 'Ephraim Bartholomew Winthrop',
+              'cvv'            : '123'
+            }
+          },
+          payoutMethod: {
+            kind           : 'BTC_ADDRESS',
+            paymentDetails : {
+              btcAddress: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+            }
+          },
+          payinAmount : '20000.00',
+          claims      : [vcJwt]
+        }
       })
 
       await rfq.verifyClaims(offering)
     })
 
     it(`throws an exception if an rfq's claims dont fulfill the provided offering's requirements`, async () => {
-      const did = await DevTools.createDid()
-      const offering = DevTools.createOffering()
-      const { signedCredential } = await DevTools.createCredential({
+      const did = await DidKeyMethod.create()
+      const offering = createUnsignedOffering()
+
+      const vc = await VerifiableCredential.create({
         type    : 'PuupuuCredential',
-        issuer  : did,
+        issuer  : did.did,
         subject : did.did,
         data    : {
           'beep': 'boop'
         }
       })
 
-      const rfqData = await DevTools.createRfqData()
-      rfqData.claims = [signedCredential]
+      const vcJwt = await vc.sign({ did })
 
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : rfqData
+        data     : {
+          offeringId  : 'abcd123',
+          payinMethod : {
+            kind           : 'DEBIT_CARD',
+            paymentDetails : {
+              'cardNumber'     : '1234567890123456',
+              'expiryDate'     : '12/22',
+              'cardHolderName' : 'Ephraim Bartholomew Winthrop',
+              'cvv'            : '123'
+            }
+          },
+          payoutMethod: {
+            kind           : 'BTC_ADDRESS',
+            paymentDetails : {
+              btcAddress: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+            }
+          },
+          payinAmount : '20000.00',
+          claims      : [vcJwt]
+        }
       })
 
       try {
@@ -335,3 +395,96 @@ describe('Rfq', () => {
     })
   })
 })
+
+function createUnsignedOffering() {
+  const offeringData: OfferingData = {
+    description   : 'Selling BTC for USD',
+    payinCurrency : {
+      currencyCode : 'USD',
+      maxAmount    : '99999999.00'
+    },
+    payoutCurrency: {
+      currencyCode : 'BTC',
+      maxAmount    : '99952611.00000'
+    },
+    payoutUnitsPerPayinUnit : '0.00003826',
+    payinMethods            : [{
+      kind                   : 'DEBIT_CARD',
+      requiredPaymentDetails : {
+        $schema    : 'http://json-schema.org/draft-07/schema',
+        type       : 'object',
+        properties : {
+          cardNumber: {
+            type        : 'string',
+            description : 'The 16-digit debit card number',
+            minLength   : 16,
+            maxLength   : 16
+          },
+          expiryDate: {
+            type        : 'string',
+            description : 'The expiry date of the card in MM/YY format',
+            pattern     : '^(0[1-9]|1[0-2])\\/([0-9]{2})$'
+          },
+          cardHolderName: {
+            type        : 'string',
+            description : 'Name of the cardholder as it appears on the card'
+          },
+          cvv: {
+            type        : 'string',
+            description : 'The 3-digit CVV code',
+            minLength   : 3,
+            maxLength   : 3
+          }
+        },
+        required             : ['cardNumber', 'expiryDate', 'cardHolderName', 'cvv'],
+        additionalProperties : false
+      }
+    }],
+    payoutMethods: [{
+      kind                   : 'BTC_ADDRESS',
+      requiredPaymentDetails : {
+        $schema    : 'http://json-schema.org/draft-07/schema',
+        type       : 'object',
+        properties : {
+          btcAddress: {
+            type        : 'string',
+            description : 'your Bitcoin wallet address'
+          }
+        },
+        required             : ['btcAddress'],
+        additionalProperties : false
+      }
+    }],
+    requiredClaims: {
+      id     : '7ce4004c-3c38-4853-968b-e411bafcd945',
+      format : {
+        'jwt_vc': {
+          'alg': [
+            'ES256K',
+            'EdDSA'
+          ]
+        }
+      },
+      input_descriptors: [{
+        id          : 'bbdb9b7c-5754-4f46-b63b-590bada959e0',
+        constraints : {
+          fields: [{
+            path: [
+              '$.vc.type[*]',
+              '$.type[*]'
+            ],
+            filter: {
+              type    : 'string',
+              pattern : '^SanctionsCredential$'
+            }
+          }]
+        }
+      }]
+    }
+  }
+
+  return Offering.create({
+    metadata : { from: 'did:ex:pfi' },
+    data     : offeringData
+  })
+}

--- a/packages/protocol/tests/rfq.spec.ts
+++ b/packages/protocol/tests/rfq.spec.ts
@@ -1,39 +1,17 @@
-import type { CreateRfqOptions, OfferingData, RfqData } from '../src/main.js'
-
 import { VerifiableCredential } from '@web5/credentials'
-import { DidKeyMethod } from '@web5/dids'
-import { Rfq, Offering } from '../src/main.js'
+import type { CreateRfqOptions, Offering } from '../src/main.js'
+
+import { Rfq, DevTools } from '../src/main.js'
 import { Convert } from '@web5/common'
 import { expect } from 'chai'
-
-const rfqData: RfqData = {
-  offeringId  : 'abcd123',
-  payinMethod : {
-    kind           : 'DEBIT_CARD',
-    paymentDetails : {
-      'cardNumber'     : '1234567890123456',
-      'expiryDate'     : '12/22',
-      'cardHolderName' : 'Ephraim Bartholomew Winthrop',
-      'cvv'            : '123'
-    }
-  },
-  payoutMethod: {
-    kind           : 'BTC_ADDRESS',
-    paymentDetails : {
-      btcAddress: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
-    }
-  },
-  payinAmount : '20000.00',
-  claims      : ['']
-}
 
 describe('Rfq', () => {
   describe('create', () => {
     it('creates an rfq', async () => {
-      const alice = await DidKeyMethod.create()
+      const alice = await DevTools.createDid()
       const message = Rfq.create({
         metadata : { from: alice.did, to: 'did:ex:pfi' },
-        data     : rfqData
+        data     : await DevTools.createRfqData()
       })
 
       expect(message.id).to.exist
@@ -68,10 +46,10 @@ describe('Rfq', () => {
 
   describe('sign', () => {
     it('sets signature property', async () => {
-      const did = await DidKeyMethod.create()
+      const did = await DevTools.createDid()
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : rfqData
+        data     : await DevTools.createRfqData()
       })
 
       await rfq.sign(did)
@@ -81,28 +59,28 @@ describe('Rfq', () => {
     })
 
     it('includes alg and kid in jws header', async () => {
-      const did = await DidKeyMethod.create()
+      const did = await DevTools.createDid()
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : rfqData
+        data     : await DevTools.createRfqData()
       })
 
       await rfq.sign(did)
 
-      const [base64UrlEncodedJwsHeader] = rfq.signature.split('.')
-      const jwsHeader = Convert.base64Url(base64UrlEncodedJwsHeader).toObject()
+      const [base64UrlEncodedJwsHeader] = rfq.signature!.split('.')
+      const jwsHeader: { kid?: string, alg?: string}  = Convert.base64Url(base64UrlEncodedJwsHeader).toObject()
 
-      expect(jwsHeader['kid']).to.equal(did.document.verificationMethod[0].id)
+      expect(jwsHeader['kid']).to.equal(did.document.verificationMethod![0].id)
       expect(jwsHeader['alg']).to.exist
     })
   })
 
   describe('verify', () => {
     it('does not throw an exception if message integrity is intact', async () => {
-      const did = await DidKeyMethod.create()
+      const did = await DevTools.createDid()
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : rfqData
+        data     : await DevTools.createRfqData()
       })
 
       await rfq.sign(did)
@@ -110,10 +88,10 @@ describe('Rfq', () => {
     })
 
     it('throws an error if no signature is present on the message provided', async () => {
-      const alice = await DidKeyMethod.create()
+      const alice = await DevTools.createDid()
       const rfq = Rfq.create({
         metadata : { from: alice.did, to: 'did:ex:pfi' },
-        data     : rfqData
+        data     : await DevTools.createRfqData()
       })
 
       try {
@@ -144,10 +122,10 @@ describe('Rfq', () => {
     })
 
     it('returns an instance of Message if parsing is successful', async () => {
-      const did = await DidKeyMethod.create()
+      const did = await DevTools.createDid()
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : rfqData
+        data     : await DevTools.createRfqData()
       })
 
       await rfq.sign(did)
@@ -159,21 +137,13 @@ describe('Rfq', () => {
     })
   })
 
-  describe('verifyOfferingRequirements', () => {
-    const offering: Offering = createUnsignedOffering()
-    const rfqOptions: CreateRfqOptions = {
-      metadata: {
-        from : '',
-        to   : 'did:ex:pfi'
-      },
-      data: {
-        ...rfqData,
-        offeringId: offering.id,
-      }
-    }
-    before(async () => {
-      const did = await DidKeyMethod.create()
-      const vc = await VerifiableCredential.create({
+  describe('verifyOfferingRequirements', async () => {
+    let offering: Offering
+    let rfqOptions: CreateRfqOptions
+
+    beforeEach(async () => {
+      const did = await DevTools.createDid()
+      const vc = await VerifiableCredential.create({ // this credential fulfills the offering's required claims
         type    : 'SanctionsCredential',
         issuer  : did.did,
         subject : did.did,
@@ -182,8 +152,19 @@ describe('Rfq', () => {
         }
       })
 
+      offering = DevTools.createOffering()
       const vcJwt = await vc.sign({ did })
 
+      rfqOptions = {
+        metadata: {
+          from : '',
+          to   : 'did:ex:pfi'
+        },
+        data: {
+          ...await DevTools.createRfqData(),
+          offeringId: offering.id,
+        }
+      }
       rfqOptions.metadata.from = did.did
       rfqOptions.data.claims = [vcJwt]
     })
@@ -205,7 +186,6 @@ describe('Rfq', () => {
     })
 
     it('throws an error if payinAmount exceeds the provided offering\'s maxAmount', async () => {
-      const offering = createUnsignedOffering()
       offering.payinCurrency.maxAmount = '0.01'
 
       const rfq = Rfq.create({
@@ -307,10 +287,9 @@ describe('Rfq', () => {
 
   describe('verifyClaims', () => {
     it(`does not throw an exception if an rfq's claims fulfill the provided offering's requirements`, async () => {
-      const did = await DidKeyMethod.create()
-      const offering = createUnsignedOffering()
-
-      const vc = await VerifiableCredential.create({
+      const did = await DevTools.createDid()
+      const offering = DevTools.createOffering()
+      const vc = await VerifiableCredential.create({ // this credential fulfills the offering's required claims
         type    : 'SanctionsCredential',
         issuer  : did.did,
         subject : did.did,
@@ -321,37 +300,20 @@ describe('Rfq', () => {
 
       const vcJwt = await vc.sign({ did })
 
+      const rfqData = await DevTools.createRfqData()
+      rfqData.claims = [vcJwt]
+
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : {
-          offeringId  : 'abcd123',
-          payinMethod : {
-            kind           : 'DEBIT_CARD',
-            paymentDetails : {
-              'cardNumber'     : '1234567890123456',
-              'expiryDate'     : '12/22',
-              'cardHolderName' : 'Ephraim Bartholomew Winthrop',
-              'cvv'            : '123'
-            }
-          },
-          payoutMethod: {
-            kind           : 'BTC_ADDRESS',
-            paymentDetails : {
-              btcAddress: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
-            }
-          },
-          payinAmount : '20000.00',
-          claims      : [vcJwt]
-        }
+        data     : rfqData
       })
 
       await rfq.verifyClaims(offering)
     })
 
     it(`throws an exception if an rfq's claims dont fulfill the provided offering's requirements`, async () => {
-      const did = await DidKeyMethod.create()
-      const offering = createUnsignedOffering()
-
+      const did = await DevTools.createDid()
+      const offering = DevTools.createOffering()
       const vc = await VerifiableCredential.create({
         type    : 'PuupuuCredential',
         issuer  : did.did,
@@ -361,30 +323,14 @@ describe('Rfq', () => {
         }
       })
 
-      const vcJwt = await vc.sign({ did })
+      const vcJwt = await vc.sign({ did})
+
+      const rfqData = await DevTools.createRfqData()
+      rfqData.claims = [vcJwt]
 
       const rfq = Rfq.create({
         metadata : { from: did.did, to: 'did:ex:pfi' },
-        data     : {
-          offeringId  : 'abcd123',
-          payinMethod : {
-            kind           : 'DEBIT_CARD',
-            paymentDetails : {
-              'cardNumber'     : '1234567890123456',
-              'expiryDate'     : '12/22',
-              'cardHolderName' : 'Ephraim Bartholomew Winthrop',
-              'cvv'            : '123'
-            }
-          },
-          payoutMethod: {
-            kind           : 'BTC_ADDRESS',
-            paymentDetails : {
-              btcAddress: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
-            }
-          },
-          payinAmount : '20000.00',
-          claims      : [vcJwt]
-        }
+        data     : rfqData
       })
 
       try {
@@ -395,96 +341,3 @@ describe('Rfq', () => {
     })
   })
 })
-
-function createUnsignedOffering() {
-  const offeringData: OfferingData = {
-    description   : 'Selling BTC for USD',
-    payinCurrency : {
-      currencyCode : 'USD',
-      maxAmount    : '99999999.00'
-    },
-    payoutCurrency: {
-      currencyCode : 'BTC',
-      maxAmount    : '99952611.00000'
-    },
-    payoutUnitsPerPayinUnit : '0.00003826',
-    payinMethods            : [{
-      kind                   : 'DEBIT_CARD',
-      requiredPaymentDetails : {
-        $schema    : 'http://json-schema.org/draft-07/schema',
-        type       : 'object',
-        properties : {
-          cardNumber: {
-            type        : 'string',
-            description : 'The 16-digit debit card number',
-            minLength   : 16,
-            maxLength   : 16
-          },
-          expiryDate: {
-            type        : 'string',
-            description : 'The expiry date of the card in MM/YY format',
-            pattern     : '^(0[1-9]|1[0-2])\\/([0-9]{2})$'
-          },
-          cardHolderName: {
-            type        : 'string',
-            description : 'Name of the cardholder as it appears on the card'
-          },
-          cvv: {
-            type        : 'string',
-            description : 'The 3-digit CVV code',
-            minLength   : 3,
-            maxLength   : 3
-          }
-        },
-        required             : ['cardNumber', 'expiryDate', 'cardHolderName', 'cvv'],
-        additionalProperties : false
-      }
-    }],
-    payoutMethods: [{
-      kind                   : 'BTC_ADDRESS',
-      requiredPaymentDetails : {
-        $schema    : 'http://json-schema.org/draft-07/schema',
-        type       : 'object',
-        properties : {
-          btcAddress: {
-            type        : 'string',
-            description : 'your Bitcoin wallet address'
-          }
-        },
-        required             : ['btcAddress'],
-        additionalProperties : false
-      }
-    }],
-    requiredClaims: {
-      id     : '7ce4004c-3c38-4853-968b-e411bafcd945',
-      format : {
-        'jwt_vc': {
-          'alg': [
-            'ES256K',
-            'EdDSA'
-          ]
-        }
-      },
-      input_descriptors: [{
-        id          : 'bbdb9b7c-5754-4f46-b63b-590bada959e0',
-        constraints : {
-          fields: [{
-            path: [
-              '$.vc.type[*]',
-              '$.type[*]'
-            ],
-            filter: {
-              type    : 'string',
-              pattern : '^SanctionsCredential$'
-            }
-          }]
-        }
-      }]
-    }
-  }
-
-  return Offering.create({
-    metadata : { from: 'did:ex:pfi' },
-    data     : offeringData
-  })
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: 0.7.34
         version: 0.7.34
       '@types/sinon':
-        specifier: 17.0.2
-        version: 17.0.2
+        specifier: 17.0.1
+        version: 17.0.1
       '@typescript-eslint/eslint-plugin':
         specifier: 5.59.0
         version: 5.59.0(@typescript-eslint/parser@5.59.0)(eslint@8.43.0)(typescript@5.2.2)
@@ -1176,6 +1176,12 @@ packages:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.4
       '@types/node': 20.9.4
+    dev: true
+
+  /@types/sinon@17.0.1:
+    resolution: {integrity: sha512-Q2Go6TJetYn5Za1+RJA1Aik61Oa2FS8SuJ0juIqUuJ5dZR4wvhKfmSdIqWtQ3P6gljKWjW0/R7FZkA4oXVL6OA==}
+    dependencies:
+      '@types/sinonjs__fake-timers': 8.1.5
     dev: true
 
   /@types/sinon@17.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,17 +55,26 @@ importers:
         specifier: workspace:*
         version: link:../protocol
       '@web5/common':
-        specifier: 0.2.1
-        version: 0.2.1
+        specifier: 0.2.2
+        version: 0.2.2
+      '@web5/credentials':
+        specifier: 0.4.1
+        version: 0.4.1
       '@web5/crypto':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.4
+        version: 0.2.4
       '@web5/dids':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.4
+        version: 0.2.4
+      ms:
+        specifier: 2.1.3
+        version: 2.1.3
       query-string:
         specifier: 8.1.0
         version: 8.1.0
+      typeid-js:
+        specifier: 0.3.0
+        version: 0.3.0
     devDependencies:
       '@playwright/test':
         specifier: 1.34.3
@@ -79,8 +88,11 @@ importers:
       '@types/mocha':
         specifier: 10.0.1
         version: 10.0.1
+      '@types/ms':
+        specifier: 0.7.34
+        version: 0.7.34
       '@types/sinon':
-        specifier: ^17.0.2
+        specifier: 17.0.2
         version: 17.0.2
       '@typescript-eslint/eslint-plugin':
         specifier: 5.59.0
@@ -134,8 +146,8 @@ importers:
         specifier: 4.4.0
         version: 4.4.0
       sinon:
-        specifier: 15.0.2
-        version: 15.0.2
+        specifier: 17.0.1
+        version: 17.0.1
       typedoc:
         specifier: 0.25.0
         version: 0.25.0(typescript@5.2.2)
@@ -198,17 +210,17 @@ importers:
         specifier: 1.3.2
         version: 1.3.2
       '@web5/common':
-        specifier: 0.2.1
-        version: 0.2.1
+        specifier: 0.2.2
+        version: 0.2.2
       '@web5/credentials':
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.4.1
+        version: 0.4.1
       '@web5/crypto':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.4
+        version: 0.2.4
       '@web5/dids':
-        specifier: 0.2.2
-        version: 0.2.2
+        specifier: 0.2.4
+        version: 0.2.4
       ajv:
         specifier: 8.12.0
         version: 8.12.0
@@ -225,6 +237,9 @@ importers:
       '@playwright/test':
         specifier: 1.34.3
         version: 1.34.3
+      '@types/sinon':
+        specifier: 17.0.2
+        version: 17.0.2
       chai:
         specifier: 4.3.10
         version: 4.3.10
@@ -268,8 +283,8 @@ importers:
         specifier: 4.4.0
         version: 4.4.0
       sinon:
-        specifier: 15.0.2
-        version: 15.0.2
+        specifier: 17.0.1
+        version: 17.0.1
       typedoc:
         specifier: 0.25.0
         version: 0.25.0(typescript@5.2.2)
@@ -957,10 +972,6 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /@scure/base@1.1.3:
-    resolution: {integrity: sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==}
-    dev: false
-
   /@sinonjs/commons@2.0.0:
     resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
     dependencies:
@@ -979,8 +990,14 @@ packages:
       '@sinonjs/commons': 3.0.0
     dev: true
 
-  /@sinonjs/samsam@7.0.1:
-    resolution: {integrity: sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==}
+  /@sinonjs/fake-timers@11.2.2:
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+    dependencies:
+      '@sinonjs/commons': 3.0.0
+    dev: true
+
+  /@sinonjs/samsam@8.0.0:
+    resolution: {integrity: sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==}
     dependencies:
       '@sinonjs/commons': 2.0.0
       lodash.get: 4.4.2
@@ -1114,6 +1131,10 @@ packages:
 
   /@types/mocha@10.0.1:
     resolution: {integrity: sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==}
+    dev: true
+
+  /@types/ms@0.7.34:
+    resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: true
 
   /@types/node@12.20.55:
@@ -1436,13 +1457,26 @@ packages:
       multiformats: 11.0.2
     dev: false
 
-  /@web5/credentials@0.3.2:
-    resolution: {integrity: sha512-hxLJfmOngglgHvIzVtxlKYFHn2atnxhH6RZCCruoHGCNVEVcKG5wXZl6D4FJ/BMlIr8SwUg8RW/I0ns0O31vqw==}
+  /@web5/common@0.2.2:
+    resolution: {integrity: sha512-dRn6SmALExeTLMTK/W5ozGarfaddK+Lraf5OjuIGLAaLfcX1RWx3oDMoY5Hr9LjfxHJC8mGXB8DnKflbeYJRgA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      level: 8.0.0
+      multiformats: 11.0.2
+      readable-stream: 4.4.2
+    dev: false
+
+  /@web5/credentials@0.4.1:
+    resolution: {integrity: sha512-GMbS/N9AqAURjH6+Mvo49AJJxe9uli5mU+dzXtGgFJhiwD4FfqRPxdO1C3R0Tj2aCY3OAQVcCKQgmLRm2hHZlw==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@sphereon/pex': 2.1.0
-      did-jwt: 7.4.5
-      uuid: 9.0.1
+      '@web5/common': 0.2.2
+      '@web5/crypto': 0.2.4
+      '@web5/dids': 0.2.4
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: false
 
   /@web5/crypto@0.2.2:
@@ -1453,6 +1487,16 @@ packages:
       '@noble/curves': 1.1.0
       '@noble/hashes': 1.3.1
       '@web5/common': 0.2.1
+    dev: false
+
+  /@web5/crypto@0.2.4:
+    resolution: {integrity: sha512-heRUuV10mZ04dWp1C2mNF/EEPw8nnRe+yAXvmclJ+4XUHL6+mY7j+hjYOTKUAQzd4ouvbHrpJM0uYcUntA3AeA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@noble/ciphers': 0.4.0
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@web5/common': 0.2.2
     dev: false
 
   /@web5/dids@0.2.2:
@@ -1472,6 +1516,32 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: false
+
+  /@web5/dids@0.2.4:
+    resolution: {integrity: sha512-e+m+xgpiM8ydTJgWcPdwmjILLMZYdl2kwahlO22mK0azSKVrg1klpGrUODzqkrWrQ5O0tnOyqEy39FcD5Sy11w==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@decentralized-identity/ion-pow-sdk': 1.0.17
+      '@decentralized-identity/ion-sdk': 1.0.1
+      '@web5/common': 0.2.2
+      '@web5/crypto': 0.2.2
+      did-resolver: 4.1.0
+      dns-packet: 5.6.1
+      level: 8.0.0
+      ms: 2.1.3
+      pkarr: 1.1.1
+      z32: 1.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
     dev: false
 
   /abstract-level@1.0.3:
@@ -2458,20 +2528,6 @@ packages:
     resolution: {integrity: sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==}
     dev: true
 
-  /did-jwt@7.4.5:
-    resolution: {integrity: sha512-PjUFy/yhYeivNrQI5EaqYvF+cRL0itARQlXPfAnUUcj4tm40fzCU/0yWkhAoAPfM41e8O+QVRqOXwg0cZjlVeg==}
-    dependencies:
-      '@noble/ciphers': 0.4.0
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@scure/base': 1.1.3
-      canonicalize: 2.0.0
-      did-resolver: 4.1.0
-      multibase: 4.0.6
-      multiformats: 9.9.0
-      uint8arrays: 3.1.1
-    dev: false
-
   /did-resolver@4.1.0:
     resolution: {integrity: sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==}
     dev: false
@@ -2895,6 +2951,11 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+    dev: false
+
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: true
@@ -2902,7 +2963,6 @@ packages:
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-    dev: true
 
   /evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
@@ -4855,7 +4915,6 @@ packages:
   /process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
-    dev: true
 
   /promise-inflight@1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
@@ -5018,6 +5077,17 @@ packages:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
     dev: true
+
+  /readable-stream@4.4.2:
+    resolution: {integrity: sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+    dev: false
 
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -5346,13 +5416,12 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /sinon@15.0.2:
-    resolution: {integrity: sha512-PCVP63XZkg0/LOqQH5rEU4LILuvTFMb5tNxTHfs6VUMNnZz2XrnGSTZbAGITjzwQWbl/Bl/8hi4G3zZWjyBwHg==}
-    deprecated: 16.1.1
+  /sinon@17.0.1:
+    resolution: {integrity: sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==}
     dependencies:
       '@sinonjs/commons': 3.0.0
-      '@sinonjs/fake-timers': 10.3.0
-      '@sinonjs/samsam': 7.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.0
       diff: 5.1.0
       nise: 5.1.5
       supports-color: 7.2.0
@@ -5599,7 +5668,6 @@ packages:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
   /strip-ansi@4.0.0:
     resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
@@ -5989,6 +6057,7 @@ packages:
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+    dev: true
 
   /uuidv7@0.4.4:
     resolution: {integrity: sha512-jjRGChg03uGp9f6wQYSO8qXkweJwRbA5WRuEQE8xLIiehIzIIi23qZSzsyvZPCPoFqkeLtZuz7Plt1LGukAInA==}


### PR DESCRIPTION
# Summary
Upgrading to latest versions of `@web5` packages (dids, common, crypto, credentials)
Removed dependency from `Jose` library in `Crypto.ts`
Using `DidResolver.dereference()` from `@web5/dids` package, which closes #147 
Using `VerifiableCredentials.create()` from `@web5/credentials` package instead of `DevTools.createCredential()`
Part of an effort to break apart https://github.com/TBD54566975/tbdex-js/pull/126 into smaller ones. Related to #122 
