### PR TITLE
Stricten http-client

### DIFF
--- a/.changeset/mighty-pandas-speak.md
+++ b/.changeset/mighty-pandas-speak.md
@@ -1,0 +1,5 @@
+---
+"@tbdex/http-client": minor
+---
+
+Stricten, tested, and remove untested code

--- a/packages/http-client/src/errors/request-error.ts
+++ b/packages/http-client/src/errors/request-error.ts
@@ -1,7 +1,7 @@
 export type RequestErrorParams = {
   message: string
   recipientDid: string
-  url?: string
+  url: string
   cause?: unknown
 }
 

--- a/packages/http-client/tests/client.spec.ts
+++ b/packages/http-client/tests/client.spec.ts
@@ -257,7 +257,7 @@ describe('client', () => {
       }
     })
 
-    it('returns exchanges array if response is ok', async () => {
+    it('returns empty exchanges array if response is ok and body is empty array', async () => {
       fetchStub.resolves({
         ok   : true,
         json : () => Promise.resolve({ data: [] })

--- a/packages/http-client/tests/tsconfig.json
+++ b/packages/http-client/tests/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "strict": true,
+    "useUnknownInCatchVariables": false,
     "outDir": "compiled",
     "declarationDir": "compiled/types",
     "sourceMap": true,

--- a/packages/http-client/tsconfig.json
+++ b/packages/http-client/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "strict": false,
+    "strict": true,
+    "useUnknownInCatchVariables": false,
     "lib": ["DOM", "es2022"],
     "rootDir": "./",
 


### PR DESCRIPTION
Turn on strict typescript and do a few small cleanups. Also, remove `discoverPFIs` because it seems to be untested, undocumented, absent from the spec, and riddled with typescript looseness that it doesn't seem worth strictening.