### PR TITLE
Use msw to test http-client requests

### DIFF
--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -75,12 +75,13 @@
     "get-func-name": "2.0.1",
     "mkdirp": "3.0.1",
     "mocha": "10.2.0",
+    "msw": "^2.2.2",
     "rimraf": "4.4.0",
     "sinon": "17.0.1",
+    "tiny-glob": "0.2.9",
     "typedoc": "0.25.0",
     "typedoc-plugin-markdown": "3.16.0",
-    "typescript": "5.2.2",
-    "tiny-glob": "0.2.9"
+    "typescript": "5.2.2"
   },
   "scripts": {
     "clean": "rimraf dist tests/compiled",

--- a/packages/http-client/tests/client-msw.spec.ts
+++ b/packages/http-client/tests/client-msw.spec.ts
@@ -1,0 +1,81 @@
+import { expect } from 'chai'
+
+import { setupServer, SetupServerApi } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+import { BearerDid, DidDht, DidJwk } from '@web5/dids';
+import { DevTools, Rfq } from '@tbdex/protocol';
+import { TbdexHttpClient } from '../src/client.js';
+import { ErrorDetail } from '../src/main.js';
+
+// NOTE: MSW Best practices
+//
+// These tests deliberately go against some of MSW's officially recommended best practices.
+// In particular, these tests make request assertions (https://mswjs.io/docs/best-practices/avoid-request-assertions).
+// MSW's reasoning is that request assertions tend to test implementation rather than behavior.
+// This makes sense for apps where one entity controls (and can freely make changes to)
+// both the client and server. However, we are implementing a spec, and must be sure that our client
+// adheres precisely to the spec in the requests' url, header, and body.
+//
+// Though other libraries (e.g. nock) supply assertions for request url, header, and body matching out of
+// the box, we choose MSW because it has support for a wide variety of environments. To adapt it for our
+// use case, we make extensive use of `server.use(http.get({ once: true, ... }))` as a form of assertion.
+
+describe('client', () => {
+  let pfiServiceEndpoint: string
+  let pfiDid: BearerDid
+  let aliceDid: BearerDid
+  let server: SetupServerApi
+  
+  before(() => {
+    server = setupServer(
+      // Init server with no default handlers.
+      // We use the `server.use(http.get({ once: true, ... }))` pattern in each test.
+      // See NOTE above for details.
+    )
+
+    // did:dht makes actual network calls on creation (publishing) and resolution
+    server.listen({ onUnhandledRequest: 'bypass' })
+  })
+
+  beforeEach(async () => {
+    pfiServiceEndpoint = 'https://fake-mocked-tbdex-server.com'
+    aliceDid = await DidJwk.create()
+    pfiDid = await DidDht.create({
+      options: {
+        services: [{
+          type            : 'PFI',
+          id              : 'pfi',
+          serviceEndpoint : pfiServiceEndpoint
+        }]
+      }
+    })
+  })
+
+  it('sends an RFQ to /exchanges/:exchange_id/rfq', async () => {
+    const rfq = await DevTools.createRfq({ sender: aliceDid, receiver: pfiDid })
+    await rfq.sign(aliceDid)
+
+    // Set up one-time request handler that returns 200 with no message body if request matches expected
+    server.use(
+      http.post(
+        `${pfiServiceEndpoint}/exchanges/*/rfq`,
+        async ({ request, params, cookies }) => {
+          const jsonBody: any = await request.json()
+
+          try {
+            expect(await Rfq.parse(jsonBody.rfq)).to.deep.equal(rfq)
+          } catch (e) {
+            return HttpResponse.json([{ detail: e.message }], { status: 500 })
+          }
+
+          return new HttpResponse('OK', {
+            status: 200,
+          })
+        },
+        { once: true }
+      )
+    )
+
+    await TbdexHttpClient.sendMessage({ message: rfq })
+  })
+})

--- a/packages/http-client/tests/client.spec.ts
+++ b/packages/http-client/tests/client.spec.ts
@@ -1,421 +1,421 @@
-import { expect } from 'chai'
-import { DidDht, DidJwk, BearerDid } from '@web5/dids'
-import { TbdexHttpClient, requestTokenRequiredClaims } from '../src/client.js'
-import {
-  RequestError,ResponseError,
-  InvalidDidError,
-  MissingServiceEndpointError,
-  RequestTokenMissingClaimsError,
-  RequestTokenAudienceMismatchError,
-  RequestTokenVerificationError,
-  RequestTokenSigningError,
-  RequestTokenIssuerSignerMismatchError
-} from '../src/errors/index.js'
-import { DevTools } from '@tbdex/protocol'
-import * as sinon from 'sinon'
-import { JwtHeaderParams, JwtPayload } from '@web5/crypto'
-import { Convert } from '@web5/common'
-import { Jwt } from '@web5/credentials'
+// import { expect } from 'chai'
+// import { DidDht, DidJwk, BearerDid } from '@web5/dids'
+// import { TbdexHttpClient, requestTokenRequiredClaims } from '../src/client.js'
+// import {
+//   RequestError,ResponseError,
+//   InvalidDidError,
+//   MissingServiceEndpointError,
+//   RequestTokenMissingClaimsError,
+//   RequestTokenAudienceMismatchError,
+//   RequestTokenVerificationError,
+//   RequestTokenSigningError,
+//   RequestTokenIssuerSignerMismatchError
+// } from '../src/errors/index.js'
+// import { DevTools } from '@tbdex/protocol'
+// import * as sinon from 'sinon'
+// import { JwtHeaderParams, JwtPayload } from '@web5/crypto'
+// import { Convert } from '@web5/common'
+// import { Jwt } from '@web5/credentials'
 
-const pfiDid: BearerDid = await DidDht.create({
-  options: {
-    services: [{
-      type            : 'PFI',
-      id              : 'pfi',
-      serviceEndpoint : 'https://localhost:9000'
-    }]
-  }
-})
+// const pfiDid: BearerDid = await DidDht.create({
+//   options: {
+//     services: [{
+//       type            : 'PFI',
+//       id              : 'pfi',
+//       serviceEndpoint : 'https://localhost:9000'
+//     }]
+//   }
+// })
 
-const aliceDid: BearerDid = await DidJwk.create()
+// const aliceDid: BearerDid = await DidJwk.create()
 
-// TODO : Instead of stubbing fetch, consider using libraries like msw
-const fetchStub = sinon.stub(globalThis, 'fetch')
-const getPfiServiceEndpointStub = sinon.stub(TbdexHttpClient, 'getPfiServiceEndpoint')
+// // TODO : Instead of stubbing fetch, consider using libraries like msw
+// const fetchStub = sinon.stub(globalThis, 'fetch')
+// const getPfiServiceEndpointStub = sinon.stub(TbdexHttpClient, 'getPfiServiceEndpoint')
 
-describe('client', () => {
-  beforeEach(() => getPfiServiceEndpointStub.resolves('https://localhost:9000'))
+// describe('client', () => {
+//   beforeEach(() => getPfiServiceEndpointStub.resolves('https://localhost:9000'))
 
-  describe('sendMessage', () => {
+//   describe('sendMessage', () => {
 
-    it('throws RequestError if service endpoint url is garbage', async () => {
-      getPfiServiceEndpointStub.resolves('garbage')
-      fetchStub.rejects({message: 'Failed to fetch on URL'})
+//     it('throws RequestError if service endpoint url is garbage', async () => {
+//       getPfiServiceEndpointStub.resolves('garbage')
+//       fetchStub.rejects({message: 'Failed to fetch on URL'})
 
-      const rfq = await DevTools.createRfq({ sender: aliceDid, receiver: pfiDid })
-      await rfq.sign(aliceDid)
+//       const rfq = await DevTools.createRfq({ sender: aliceDid, receiver: pfiDid })
+//       await rfq.sign(aliceDid)
 
-      try {
-        await TbdexHttpClient.sendMessage({ message: rfq })
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('RequestError')
-        expect(e).to.be.instanceof(RequestError)
-        expect(e.message).to.include('Failed to send message')
-        expect(e.cause).to.exist
-        expect(e.cause.message).to.include('URL')
-      }
-    })
+//       try {
+//         await TbdexHttpClient.sendMessage({ message: rfq })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('RequestError')
+//         expect(e).to.be.instanceof(RequestError)
+//         expect(e.message).to.include('Failed to send message')
+//         expect(e.cause).to.exist
+//         expect(e.cause.message).to.include('URL')
+//       }
+//     })
 
-    it('throws ResponseError if response status is not ok', async () => {
-      fetchStub.resolves({
-        ok     : false,
-        status : 400,
-        json   : () => Promise.resolve({
-          detail: 'some error'
-        })
-      } as Response)
+//     it('throws ResponseError if response status is not ok', async () => {
+//       fetchStub.resolves({
+//         ok     : false,
+//         status : 400,
+//         json   : () => Promise.resolve({
+//           detail: 'some error'
+//         })
+//       } as Response)
 
-      const rfq = await DevTools.createRfq({ sender: aliceDid, receiver: pfiDid })
-      await rfq.sign(aliceDid)
+//       const rfq = await DevTools.createRfq({ sender: aliceDid, receiver: pfiDid })
+//       await rfq.sign(aliceDid)
 
-      try {
-        await TbdexHttpClient.sendMessage({message: rfq })
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('ResponseError')
-        expect(e).to.be.instanceof(ResponseError)
-        expect(e.statusCode).to.exist
-        expect(e.details).to.exist
-        expect(e.recipientDid).to.equal(pfiDid.uri)
-        expect(e.url).to.equal(`https://localhost:9000/exchanges/${rfq.metadata.exchangeId}/rfq`)
-      }
-    })
+//       try {
+//         await TbdexHttpClient.sendMessage({message: rfq })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('ResponseError')
+//         expect(e).to.be.instanceof(ResponseError)
+//         expect(e.statusCode).to.exist
+//         expect(e.details).to.exist
+//         expect(e.recipientDid).to.equal(pfiDid.uri)
+//         expect(e.url).to.equal(`https://localhost:9000/exchanges/${rfq.metadata.exchangeId}/rfq`)
+//       }
+//     })
 
-    it('should not throw errors if all is well when sending RFQ with replyTo field', async () => {
-      fetchStub.resolves({
-        ok   : true,
-        json : () => Promise.resolve()
-      } as Response)
+//     it('should not throw errors if all is well when sending RFQ with replyTo field', async () => {
+//       fetchStub.resolves({
+//         ok   : true,
+//         json : () => Promise.resolve()
+//       } as Response)
 
-      const rfq = await DevTools.createRfq({ sender: aliceDid, receiver: pfiDid })
-      await rfq.sign(aliceDid)
+//       const rfq = await DevTools.createRfq({ sender: aliceDid, receiver: pfiDid })
+//       await rfq.sign(aliceDid)
 
-      try {
-        await TbdexHttpClient.sendMessage({message: rfq, replyTo: 'https://tbdex.io/callback'})
-      } catch (e) {
-        expect.fail()
-      }
-    })
+//       try {
+//         await TbdexHttpClient.sendMessage({message: rfq, replyTo: 'https://tbdex.io/callback'})
+//       } catch (e) {
+//         expect.fail()
+//       }
+//     })
 
-    it('should not throw errors if all is well when sending RFQ without replyTo field', async () => {
-      fetchStub.resolves({
-        ok   : true,
-        json : () => Promise.resolve()
-      } as Response)
+//     it('should not throw errors if all is well when sending RFQ without replyTo field', async () => {
+//       fetchStub.resolves({
+//         ok   : true,
+//         json : () => Promise.resolve()
+//       } as Response)
 
-      const rfq = await DevTools.createRfq({ sender: aliceDid, receiver: pfiDid })
-      await rfq.sign(aliceDid)
+//       const rfq = await DevTools.createRfq({ sender: aliceDid, receiver: pfiDid })
+//       await rfq.sign(aliceDid)
 
-      try {
-        await TbdexHttpClient.sendMessage({ message: rfq })
-      } catch (e) {
-        expect.fail()
-      }
-    })
-  })
+//       try {
+//         await TbdexHttpClient.sendMessage({ message: rfq })
+//       } catch (e) {
+//         expect.fail()
+//       }
+//     })
+//   })
 
-  describe('getOfferings', () => {
-    it('throws RequestError if service endpoint url is garbage', async () => {
-      getPfiServiceEndpointStub.resolves('garbage')
-      fetchStub.rejects({message: 'Failed to fetch on URL'})
+//   describe('getOfferings', () => {
+//     it('throws RequestError if service endpoint url is garbage', async () => {
+//       getPfiServiceEndpointStub.resolves('garbage')
+//       fetchStub.rejects({message: 'Failed to fetch on URL'})
 
-      try {
-        await TbdexHttpClient.getOfferings({ pfiDid: pfiDid.uri })
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('RequestError')
-        expect(e).to.be.instanceof(RequestError)
-        expect(e.message).to.include('Failed to get offerings')
-        expect(e.cause).to.exist
-        expect(e.cause.message).to.include('URL')
-      }
-    })
+//       try {
+//         await TbdexHttpClient.getOfferings({ pfiDid: pfiDid.uri })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('RequestError')
+//         expect(e).to.be.instanceof(RequestError)
+//         expect(e.message).to.include('Failed to get offerings')
+//         expect(e.cause).to.exist
+//         expect(e.cause.message).to.include('URL')
+//       }
+//     })
 
-    it('throws ResponseError if response status is not ok', async () => {
-      fetchStub.resolves({
-        ok     : false,
-        status : 400,
-        json   : () => Promise.resolve({
-          detail: 'some error'
-        })
-      } as Response)
+//     it('throws ResponseError if response status is not ok', async () => {
+//       fetchStub.resolves({
+//         ok     : false,
+//         status : 400,
+//         json   : () => Promise.resolve({
+//           detail: 'some error'
+//         })
+//       } as Response)
 
-      try {
-        await TbdexHttpClient.getOfferings({ pfiDid: pfiDid.uri })
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('ResponseError')
-        expect(e).to.be.instanceof(ResponseError)
-        expect(e.statusCode).to.exist
-        expect(e.details).to.exist
-        expect(e.recipientDid).to.equal(pfiDid.uri)
-        expect(e.url).to.equal('https://localhost:9000/offerings')
-      }
-    })
+//       try {
+//         await TbdexHttpClient.getOfferings({ pfiDid: pfiDid.uri })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('ResponseError')
+//         expect(e).to.be.instanceof(ResponseError)
+//         expect(e.statusCode).to.exist
+//         expect(e.details).to.exist
+//         expect(e.recipientDid).to.equal(pfiDid.uri)
+//         expect(e.url).to.equal('https://localhost:9000/offerings')
+//       }
+//     })
 
-    it('returns offerings array if response is ok', async () => {
-      fetchStub.resolves({
-        ok   : true,
-        json : () => Promise.resolve({ data: [] })
-      } as Response)
+//     it('returns offerings array if response is ok', async () => {
+//       fetchStub.resolves({
+//         ok   : true,
+//         json : () => Promise.resolve({ data: [] })
+//       } as Response)
 
-      const offerings = await TbdexHttpClient.getOfferings({ pfiDid: pfiDid.uri })
-      expect(offerings).to.have.length(0)
-    })
-  })
+//       const offerings = await TbdexHttpClient.getOfferings({ pfiDid: pfiDid.uri })
+//       expect(offerings).to.have.length(0)
+//     })
+//   })
 
-  describe('getExchange', () => {
-    it('throws RequestError if service endpoint url is garbage', async () => {
-      getPfiServiceEndpointStub.resolves('garbage')
-      fetchStub.rejects({message: 'Failed to fetch on URL'})
+//   describe('getExchange', () => {
+//     it('throws RequestError if service endpoint url is garbage', async () => {
+//       getPfiServiceEndpointStub.resolves('garbage')
+//       fetchStub.rejects({message: 'Failed to fetch on URL'})
 
-      try {
-        await TbdexHttpClient.getExchange({ pfiDid: pfiDid.uri, exchangeId: '123', did: pfiDid })
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('RequestError')
-        expect(e).to.be.instanceof(RequestError)
-        expect(e.message).to.include('Failed to get exchange')
-        expect(e.cause).to.exist
-        expect(e.cause.message).to.include('URL')
-      }
-    })
+//       try {
+//         await TbdexHttpClient.getExchange({ pfiDid: pfiDid.uri, exchangeId: '123', did: pfiDid })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('RequestError')
+//         expect(e).to.be.instanceof(RequestError)
+//         expect(e.message).to.include('Failed to get exchange')
+//         expect(e.cause).to.exist
+//         expect(e.cause.message).to.include('URL')
+//       }
+//     })
 
-    it('throws ResponseError if response status is not ok', async () => {
-      fetchStub.resolves({
-        ok     : false,
-        status : 400,
-        json   : () => Promise.resolve({
-          detail: 'some error'
-        })
-      } as Response)
+//     it('throws ResponseError if response status is not ok', async () => {
+//       fetchStub.resolves({
+//         ok     : false,
+//         status : 400,
+//         json   : () => Promise.resolve({
+//           detail: 'some error'
+//         })
+//       } as Response)
 
-      try {
-        await TbdexHttpClient.getExchange({ pfiDid: pfiDid.uri, exchangeId: '123', did: pfiDid })
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('ResponseError')
-        expect(e).to.be.instanceof(ResponseError)
-        expect(e.statusCode).to.exist
-        expect(e.details).to.exist
-        expect(e.recipientDid).to.equal(pfiDid.uri)
-        expect(e.url).to.equal('https://localhost:9000/exchanges/123')
-      }
-    })
+//       try {
+//         await TbdexHttpClient.getExchange({ pfiDid: pfiDid.uri, exchangeId: '123', did: pfiDid })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('ResponseError')
+//         expect(e).to.be.instanceof(ResponseError)
+//         expect(e.statusCode).to.exist
+//         expect(e.details).to.exist
+//         expect(e.recipientDid).to.equal(pfiDid.uri)
+//         expect(e.url).to.equal('https://localhost:9000/exchanges/123')
+//       }
+//     })
 
-    it('returns exchange array if response is ok', async () => {
-      fetchStub.resolves({
-        ok   : true,
-        json : () => Promise.resolve({ data: [] })
-      } as Response)
+//     it('returns exchange array if response is ok', async () => {
+//       fetchStub.resolves({
+//         ok   : true,
+//         json : () => Promise.resolve({ data: [] })
+//       } as Response)
 
-      const exchanges = await TbdexHttpClient.getExchange({ pfiDid: pfiDid.uri, exchangeId: '123', did: pfiDid })
-      expect(exchanges).to.have.length(0)
-    })
-  })
+//       const exchanges = await TbdexHttpClient.getExchange({ pfiDid: pfiDid.uri, exchangeId: '123', did: pfiDid })
+//       expect(exchanges).to.have.length(0)
+//     })
+//   })
 
-  describe('getExchanges', () => {
-    it('throws RequestError if service endpoint url is garbage', async () => {
-      getPfiServiceEndpointStub.resolves('garbage')
-      fetchStub.rejects({message: 'Failed to fetch on URL'})
+//   describe('getExchanges', () => {
+//     it('throws RequestError if service endpoint url is garbage', async () => {
+//       getPfiServiceEndpointStub.resolves('garbage')
+//       fetchStub.rejects({message: 'Failed to fetch on URL'})
 
-      try {
-        await TbdexHttpClient.getExchanges({ pfiDid: pfiDid.uri, did: pfiDid })
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('RequestError')
-        expect(e).to.be.instanceof(RequestError)
-        expect(e.message).to.include('Failed to get exchanges')
-        expect(e.cause).to.exist
-        expect(e.cause.message).to.include('URL')
-      }
-    })
+//       try {
+//         await TbdexHttpClient.getExchanges({ pfiDid: pfiDid.uri, did: pfiDid })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('RequestError')
+//         expect(e).to.be.instanceof(RequestError)
+//         expect(e.message).to.include('Failed to get exchanges')
+//         expect(e.cause).to.exist
+//         expect(e.cause.message).to.include('URL')
+//       }
+//     })
 
-    it('throws ResponseError if response status is not ok', async () => {
-      fetchStub.resolves({
-        ok     : false,
-        status : 400,
-        json   : () => Promise.resolve({
-          detail: 'some error'
-        })
-      } as Response)
+//     it('throws ResponseError if response status is not ok', async () => {
+//       fetchStub.resolves({
+//         ok     : false,
+//         status : 400,
+//         json   : () => Promise.resolve({
+//           detail: 'some error'
+//         })
+//       } as Response)
 
-      try {
-        await TbdexHttpClient.getExchanges({ pfiDid: pfiDid.uri, did: pfiDid })
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('ResponseError')
-        expect(e).to.be.instanceof(ResponseError)
-        expect(e.statusCode).to.exist
-        expect(e.details).to.exist
-        expect(e.recipientDid).to.equal(pfiDid.uri)
-        expect(e.url).to.equal('https://localhost:9000/exchanges')
-      }
-    })
+//       try {
+//         await TbdexHttpClient.getExchanges({ pfiDid: pfiDid.uri, did: pfiDid })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('ResponseError')
+//         expect(e).to.be.instanceof(ResponseError)
+//         expect(e.statusCode).to.exist
+//         expect(e.details).to.exist
+//         expect(e.recipientDid).to.equal(pfiDid.uri)
+//         expect(e.url).to.equal('https://localhost:9000/exchanges')
+//       }
+//     })
 
-    it('returns empty exchanges array if response is ok and body is empty array', async () => {
-      fetchStub.resolves({
-        ok   : true,
-        json : () => Promise.resolve({ data: [] })
-      } as Response)
+//     it('returns empty exchanges array if response is ok and body is empty array', async () => {
+//       fetchStub.resolves({
+//         ok   : true,
+//         json : () => Promise.resolve({ data: [] })
+//       } as Response)
 
-      const exchanges = await TbdexHttpClient.getExchanges({ pfiDid: pfiDid.uri, did: pfiDid })
-      expect(exchanges).to.have.length(0)
-    })
-  })
+//       const exchanges = await TbdexHttpClient.getExchanges({ pfiDid: pfiDid.uri, did: pfiDid })
+//       expect(exchanges).to.have.length(0)
+//     })
+//   })
 
-  describe('getPfiServiceEndpoint', () => {
-    before(() => {
-      getPfiServiceEndpointStub.restore()
-      fetchStub.restore()
-    })
+//   describe('getPfiServiceEndpoint', () => {
+//     before(() => {
+//       getPfiServiceEndpointStub.restore()
+//       fetchStub.restore()
+//     })
 
-    it('throws InvalidDidError if did is pewpew', async () => {
-      try {
-        await TbdexHttpClient.getPfiServiceEndpoint('hehetroll')
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('InvalidDidError')
-        expect(e).to.be.instanceof(InvalidDidError)
-        expect(e.message).to.exist
-      }
-    })
-    it('throws MissingServiceEndpointError if did has no PFI service endpoint', async () => {
-      try {
-        await TbdexHttpClient.getPfiServiceEndpoint(aliceDid.uri)
-        expect.fail()
-      } catch(e) {
-        expect(e.name).to.equal('MissingServiceEndpointError')
-        expect(e).to.be.instanceof(MissingServiceEndpointError)
-        expect(e.message).to.include('has no PFI service entry')
-      }
-    })
-    it('returns pfi service endpoint if all is well', async () => {
-      const serviceEndpoint = await TbdexHttpClient.getPfiServiceEndpoint(pfiDid.uri)
-      expect(serviceEndpoint).to.equal('https://localhost:9000')
-    })
-  })
+//     it('throws InvalidDidError if did is pewpew', async () => {
+//       try {
+//         await TbdexHttpClient.getPfiServiceEndpoint('hehetroll')
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('InvalidDidError')
+//         expect(e).to.be.instanceof(InvalidDidError)
+//         expect(e.message).to.exist
+//       }
+//     })
+//     it('throws MissingServiceEndpointError if did has no PFI service endpoint', async () => {
+//       try {
+//         await TbdexHttpClient.getPfiServiceEndpoint(aliceDid.uri)
+//         expect.fail()
+//       } catch(e) {
+//         expect(e.name).to.equal('MissingServiceEndpointError')
+//         expect(e).to.be.instanceof(MissingServiceEndpointError)
+//         expect(e.message).to.include('has no PFI service entry')
+//       }
+//     })
+//     it('returns pfi service endpoint if all is well', async () => {
+//       const serviceEndpoint = await TbdexHttpClient.getPfiServiceEndpoint(pfiDid.uri)
+//       expect(serviceEndpoint).to.equal('https://localhost:9000')
+//     })
+//   })
 
-  describe('generateRequestToken', () => {
-    let requesterBearerDid: BearerDid
-    before(async () => {
-      requesterBearerDid = await DidJwk.create()
-    })
-    it('includes all expected claims', async () => {
-      const requestToken = await TbdexHttpClient.generateRequestToken({ requesterDid: requesterBearerDid, pfiDid: 'did:key:1234' })
-      const decodedToken = await Jwt.verify({ jwt: requestToken })
-      expect(decodedToken.payload).to.have.all.keys(requestTokenRequiredClaims)
-    })
-    // TODO: decide if we want to ensure that the expiration date is not longer than 1 minute after the issuance date
-    it('sets expiration seconds to 1 minute after the time at which it was issued', async () => {
-      const requestToken = await TbdexHttpClient.generateRequestToken({ requesterDid: requesterBearerDid, pfiDid: 'did:key:1234' })
-      const decodedToken = await Jwt.verify({ jwt: requestToken })
-      expect(decodedToken.payload.exp! - decodedToken.payload.iat!).to.equal(60)
-    })
-  })
+//   describe('generateRequestToken', () => {
+//     let requesterBearerDid: BearerDid
+//     before(async () => {
+//       requesterBearerDid = await DidJwk.create()
+//     })
+//     it('includes all expected claims', async () => {
+//       const requestToken = await TbdexHttpClient.generateRequestToken({ requesterDid: requesterBearerDid, pfiDid: 'did:key:1234' })
+//       const decodedToken = await Jwt.verify({ jwt: requestToken })
+//       expect(decodedToken.payload).to.have.all.keys(requestTokenRequiredClaims)
+//     })
+//     // TODO: decide if we want to ensure that the expiration date is not longer than 1 minute after the issuance date
+//     it('sets expiration seconds to 1 minute after the time at which it was issued', async () => {
+//       const requestToken = await TbdexHttpClient.generateRequestToken({ requesterDid: requesterBearerDid, pfiDid: 'did:key:1234' })
+//       const decodedToken = await Jwt.verify({ jwt: requestToken })
+//       expect(decodedToken.payload.exp! - decodedToken.payload.iat!).to.equal(60)
+//     })
+//   })
 
-  describe('verifyRequestToken', () => {
-    let pfiBearerDid: BearerDid
-    let aliceBearerDid: BearerDid
-    let header: JwtHeaderParams
-    let payload: JwtPayload
+//   describe('verifyRequestToken', () => {
+//     let pfiBearerDid: BearerDid
+//     let aliceBearerDid: BearerDid
+//     let header: JwtHeaderParams
+//     let payload: JwtPayload
 
-    /*
-    ** helper function to help alice generate a valid request token to send to a pfi
-    */
-    async function createAndSignRequestToken(payload: JwtPayload) {
-      const signer = await aliceBearerDid.getSigner()
-      header = { typ: 'JWT', alg: signer.algorithm, kid: signer.keyId }
-      const base64UrlEncodedHeader = Convert.object(header).toBase64Url()
-      const base64UrlEncodedPayload = Convert.object(payload).toBase64Url()
+//     /*
+//     ** helper function to help alice generate a valid request token to send to a pfi
+//     */
+//     async function createAndSignRequestToken(payload: JwtPayload) {
+//       const signer = await aliceBearerDid.getSigner()
+//       header = { typ: 'JWT', alg: signer.algorithm, kid: signer.keyId }
+//       const base64UrlEncodedHeader = Convert.object(header).toBase64Url()
+//       const base64UrlEncodedPayload = Convert.object(payload).toBase64Url()
 
-      const toSign = `${base64UrlEncodedHeader}.${base64UrlEncodedPayload}`
-      const toSignBytes = Convert.string(toSign).toUint8Array()
-      const signatureBytes = await signer.sign({ data: toSignBytes })
-      const base64UrlEncodedSignature = Convert.uint8Array(signatureBytes).toBase64Url()
+//       const toSign = `${base64UrlEncodedHeader}.${base64UrlEncodedPayload}`
+//       const toSignBytes = Convert.string(toSign).toUint8Array()
+//       const signatureBytes = await signer.sign({ data: toSignBytes })
+//       const base64UrlEncodedSignature = Convert.uint8Array(signatureBytes).toBase64Url()
 
-      return `${toSign}.${base64UrlEncodedSignature}`
-    }
+//       return `${toSign}.${base64UrlEncodedSignature}`
+//     }
 
-    before(async () => {
-      pfiBearerDid = await DidDht.create()
-      aliceBearerDid = await DidDht.create()
-      header = { typ: 'JWT', alg: 'ES256K', kid: aliceBearerDid.document.verificationMethod![0].id }
-    })
+//     before(async () => {
+//       pfiBearerDid = await DidDht.create()
+//       aliceBearerDid = await DidDht.create()
+//       header = { typ: 'JWT', alg: 'ES256K', kid: aliceBearerDid.document.verificationMethod![0].id }
+//     })
 
-    beforeEach(() => {
-      payload = {
-        iat : Math.floor(Date.now() / 1000),
-        aud : pfiBearerDid.uri,
-        iss : aliceBearerDid.uri,
-        exp : Math.floor(Date.now() / 1000 + 60),
-        jti : 'randomnonce'
-      }
-    })
+//     beforeEach(() => {
+//       payload = {
+//         iat : Math.floor(Date.now() / 1000),
+//         aud : pfiBearerDid.uri,
+//         iss : aliceBearerDid.uri,
+//         exp : Math.floor(Date.now() / 1000 + 60),
+//         jti : 'randomnonce'
+//       }
+//     })
 
-    it('throws a RequestTokenSigningError if token cannot be signed', async () => {
-      const jwtSigner = sinon.stub(Jwt, 'sign')
-      jwtSigner.throws()
-      try {
-        await TbdexHttpClient.generateRequestToken({ requesterDid: aliceBearerDid, pfiDid: ''})
-        expect.fail()
-      } catch (e) {
-        expect(e).to.be.instanceOf(RequestTokenSigningError)
-      }
-      jwtSigner.restore()
-    })
+//     it('throws a RequestTokenSigningError if token cannot be signed', async () => {
+//       const jwtSigner = sinon.stub(Jwt, 'sign')
+//       jwtSigner.throws()
+//       try {
+//         await TbdexHttpClient.generateRequestToken({ requesterDid: aliceBearerDid, pfiDid: ''})
+//         expect.fail()
+//       } catch (e) {
+//         expect(e).to.be.instanceOf(RequestTokenSigningError)
+//       }
+//       jwtSigner.restore()
+//     })
 
-    it('throws RequestTokenVerificationError if request token is not a valid jwt', async () => {
-      try {
-        await TbdexHttpClient.verifyRequestToken({ requestToken: '', pfiDid: pfiBearerDid.uri })
-        expect.fail()
-      } catch(e) {
-        expect(e).to.be.instanceof(RequestTokenVerificationError)
-      }
-    })
-    it('throws RequestTokenMissingClaimsError if request token is missing any of the expected claims', async () => {
-      for (const claim of requestTokenRequiredClaims) {
-        const initialClaim = payload[claim]
-        try {
-          delete payload[claim]
-          const requestToken = await createAndSignRequestToken(payload)
-          await TbdexHttpClient.verifyRequestToken({ requestToken, pfiDid: pfiBearerDid.uri })
-          expect.fail()
-        } catch(e) {
-          expect(e).to.be.instanceof(RequestTokenMissingClaimsError)
-          expect(e.message).to.include(`Request token missing ${claim} claim.`)
-        }
-        payload[claim] = initialClaim
-      }
-    })
-    it('throws RequestTokenAudienceMismatchError if aud claim does not match pfi did', async () => {
-      try {
-        payload.aud = 'squirtle'
-        const requestToken = await createAndSignRequestToken(payload)
-        await TbdexHttpClient.verifyRequestToken({ requestToken, pfiDid: pfiBearerDid.uri })
-        expect.fail()
-      } catch(e) {
-        expect(e).to.be.instanceof(RequestTokenAudienceMismatchError)
-        expect(e.message).to.include('Request token contains invalid audience')
-      }
-    })
-    it('throws RequestTokenIssuerSignerMismatchError if iss claim does not match kid header', async () => {
-      try {
-        const bobBearerDid = await DidDht.create()
-        payload.iss = bobBearerDid.uri
-        const requestToken = await createAndSignRequestToken(payload)
-        await TbdexHttpClient.verifyRequestToken({ requestToken, pfiDid: pfiBearerDid.uri })
-        expect.fail()
-      } catch(e) {
-        expect(e).to.be.instanceof(RequestTokenIssuerSignerMismatchError)
-        expect(e.message).to.include('Request token issuer does not match signer')
-      }
-    })
-    it('returns requester\'s DID if request token is valid', async () => {
-      const requestToken = await createAndSignRequestToken(payload)
-      const iss = await TbdexHttpClient.verifyRequestToken({ requestToken, pfiDid: pfiBearerDid.uri })
-      expect(iss).to.equal(aliceBearerDid.uri)
-    })
-  })
-})
+//     it('throws RequestTokenVerificationError if request token is not a valid jwt', async () => {
+//       try {
+//         await TbdexHttpClient.verifyRequestToken({ requestToken: '', pfiDid: pfiBearerDid.uri })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e).to.be.instanceof(RequestTokenVerificationError)
+//       }
+//     })
+//     it('throws RequestTokenMissingClaimsError if request token is missing any of the expected claims', async () => {
+//       for (const claim of requestTokenRequiredClaims) {
+//         const initialClaim = payload[claim]
+//         try {
+//           delete payload[claim]
+//           const requestToken = await createAndSignRequestToken(payload)
+//           await TbdexHttpClient.verifyRequestToken({ requestToken, pfiDid: pfiBearerDid.uri })
+//           expect.fail()
+//         } catch(e) {
+//           expect(e).to.be.instanceof(RequestTokenMissingClaimsError)
+//           expect(e.message).to.include(`Request token missing ${claim} claim.`)
+//         }
+//         payload[claim] = initialClaim
+//       }
+//     })
+//     it('throws RequestTokenAudienceMismatchError if aud claim does not match pfi did', async () => {
+//       try {
+//         payload.aud = 'squirtle'
+//         const requestToken = await createAndSignRequestToken(payload)
+//         await TbdexHttpClient.verifyRequestToken({ requestToken, pfiDid: pfiBearerDid.uri })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e).to.be.instanceof(RequestTokenAudienceMismatchError)
+//         expect(e.message).to.include('Request token contains invalid audience')
+//       }
+//     })
+//     it('throws RequestTokenIssuerSignerMismatchError if iss claim does not match kid header', async () => {
+//       try {
+//         const bobBearerDid = await DidDht.create()
+//         payload.iss = bobBearerDid.uri
+//         const requestToken = await createAndSignRequestToken(payload)
+//         await TbdexHttpClient.verifyRequestToken({ requestToken, pfiDid: pfiBearerDid.uri })
+//         expect.fail()
+//       } catch(e) {
+//         expect(e).to.be.instanceof(RequestTokenIssuerSignerMismatchError)
+//         expect(e.message).to.include('Request token issuer does not match signer')
+//       }
+//     })
+//     it('returns requester\'s DID if request token is valid', async () => {
+//       const requestToken = await createAndSignRequestToken(payload)
+//       const iss = await TbdexHttpClient.verifyRequestToken({ requestToken, pfiDid: pfiBearerDid.uri })
+//       expect(iss).to.equal(aliceBearerDid.uri)
+//     })
+//   })
+// })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       mocha:
         specifier: 10.2.0
         version: 10.2.0
+      msw:
+        specifier: ^2.2.2
+        version: 2.2.2(typescript@5.2.2)
       rimraf:
         specifier: 4.4.0
         version: 4.4.0
@@ -340,6 +343,18 @@ packages:
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
+
+  /@bundled-es-modules/cookie@2.0.0:
+    resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
+    dependencies:
+      cookie: 0.5.0
+    dev: true
+
+  /@bundled-es-modules/statuses@1.0.1:
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+    dependencies:
+      statuses: 2.0.1
     dev: true
 
   /@changesets/apply-release-plan@6.1.4:
@@ -838,6 +853,39 @@ packages:
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
     dev: true
 
+  /@inquirer/confirm@3.0.0:
+    resolution: {integrity: sha512-LHeuYP1D8NmQra1eR4UqvZMXwxEdDXyElJmmZfU44xdNLL6+GcQBS0uE16vyfZVjH8c22p9e+DStROfE/hyHrg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/core': 7.0.0
+      '@inquirer/type': 1.2.0
+    dev: true
+
+  /@inquirer/core@7.0.0:
+    resolution: {integrity: sha512-g13W5yEt9r1sEVVriffJqQ8GWy94OnfxLCreNSOTw0HPVcszmc/If1KIf7YBmlwtX4klmvwpZHnQpl3N7VX2xA==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@inquirer/type': 1.2.0
+      '@types/mute-stream': 0.0.4
+      '@types/node': 20.11.24
+      '@types/wrap-ansi': 3.0.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-spinners: 2.9.2
+      cli-width: 4.1.0
+      figures: 3.2.0
+      mute-stream: 1.0.0
+      run-async: 3.0.0
+      signal-exit: 4.1.0
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+    dev: true
+
+  /@inquirer/type@1.2.0:
+    resolution: {integrity: sha512-/vvkUkYhrjbm+RolU7V1aUFDydZVKNKqKHR5TsE+j5DXgXFwrsOPcoGUJ02K0O7q7O53CU2DOTMYCHeGZ25WHA==}
+    engines: {node: '>=18'}
+    dev: true
+
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -893,6 +941,23 @@ packages:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+    dev: true
+
+  /@mswjs/cookies@1.1.0:
+    resolution: {integrity: sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /@mswjs/interceptors@0.25.16:
+    resolution: {integrity: sha512-8QC8JyKztvoGAdPgyZy49c9vSHHAZjHagwl4RY9E8carULk8ym3iTaiawrT1YoLF/qb449h48f71XDPgkUSOUg==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      strict-event-emitter: 0.5.1
     dev: true
 
   /@multiformats/base-x@4.0.1:
@@ -979,6 +1044,21 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
       which: 4.0.0
+    dev: true
+
+  /@open-draft/deferred-promise@2.2.0:
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
     dev: true
 
   /@pkgjs/parseargs@0.11.0:
@@ -1255,6 +1335,10 @@ packages:
     resolution: {integrity: sha512-ag0BfJLZf6CQz8VIuRIEYQ5Ggwk/82uvTQf27RcpyDNbY0Vw49LIPqAxk5tqYfrCs9xDaIMvl4aj7ZopnYL8bA==}
     dev: true
 
+  /@types/cookie@0.6.0:
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+    dev: true
+
   /@types/cookies@0.7.10:
     resolution: {integrity: sha512-hmUCjAk2fwZVPPkkPBcI7jGLIR5mg4OVoNMBwU6aVsMm/iNPY7z9/R+x2fSwLt/ZXoGua6C5Zy2k5xOo9jUyhQ==}
     dependencies:
@@ -1387,8 +1471,20 @@ packages:
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
     dev: true
 
+  /@types/mute-stream@0.0.4:
+    resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
+    dependencies:
+      '@types/node': 7.10.14
+    dev: true
+
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+    dev: true
+
+  /@types/node@20.11.24:
+    resolution: {integrity: sha512-Kza43ewS3xoLgCEpQrsT+xRo/EJej1y0kVYGiLFE1NEODXGzTfwiC6tXTLMQskn1X4/Rjlh0MQUvx9W+L9long==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/node@20.9.4:
@@ -1459,6 +1555,14 @@ packages:
 
   /@types/sinonjs__fake-timers@8.1.5:
     resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
+    dev: true
+
+  /@types/statuses@2.0.4:
+    resolution: {integrity: sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==}
+    dev: true
+
+  /@types/wrap-ansi@3.0.0:
+    resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
     dev: true
 
   /@types/ws@7.4.7:
@@ -2680,6 +2784,16 @@ packages:
       restore-cursor: 3.1.0
     dev: true
 
+  /cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+    dev: true
+
   /cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
     dependencies:
@@ -2819,7 +2933,6 @@ packages:
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -3646,6 +3759,13 @@ packages:
       pend: 1.2.0
     dev: true
 
+  /figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
+    dependencies:
+      escape-string-regexp: 1.0.5
+    dev: true
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3995,6 +4115,11 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /graphql@16.8.1:
+    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
+
   /handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -4070,6 +4195,10 @@ packages:
   /he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+    dev: true
+
+  /headers-polyfill@4.0.2:
+    resolution: {integrity: sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==}
     dev: true
 
   /hexoid@1.0.0:
@@ -4357,6 +4486,10 @@ packages:
   /is-negative-zero@2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
+
+  /is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+    dev: true
 
   /is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
@@ -5083,6 +5216,37 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  /msw@2.2.2(typescript@5.2.2):
+    resolution: {integrity: sha512-Vn3RGCmp14Oy1Lo9yGJMk4+qV/WdK8opNyHt0jdBnvzQ8OEhFvQ2AeM9EXOgQtGLvzUWzqrrwlfwmsCkFViUlg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      typescript: '>= 4.7.x <= 5.3.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.0
+      '@bundled-es-modules/statuses': 1.0.1
+      '@inquirer/confirm': 3.0.0
+      '@mswjs/cookies': 1.1.0
+      '@mswjs/interceptors': 0.25.16
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.4
+      chalk: 4.1.2
+      graphql: 16.8.1
+      headers-polyfill: 4.0.2
+      is-node-process: 1.2.0
+      outvariant: 1.4.2
+      path-to-regexp: 6.2.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.10.3
+      typescript: 5.2.2
+      yargs: 17.7.2
+    dev: true
+
   /multibase@4.0.6:
     resolution: {integrity: sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==}
     engines: {node: '>=12.0.0', npm: '>=6.0.0'}
@@ -5113,6 +5277,11 @@ packages:
       uint8arrays: 3.1.1
       varint: 5.0.2
     dev: false
+
+  /mute-stream@1.0.0:
+    resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: true
 
   /nanocolors@0.2.13:
     resolution: {integrity: sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA==}
@@ -5384,6 +5553,10 @@ packages:
 
   /outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+    dev: true
+
+  /outvariant@1.4.2:
+    resolution: {integrity: sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==}
     dev: true
 
   /p-filter@2.1.0:
@@ -6013,6 +6186,11 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /run-async@3.0.0:
+    resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
   /run-parallel-limit@1.1.0:
     resolution: {integrity: sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==}
     dependencies:
@@ -6351,6 +6529,10 @@ packages:
     dependencies:
       fast-fifo: 1.3.2
       queue-tick: 1.0.1
+    dev: true
+
+  /strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
     dev: true
 
   /string-width@4.2.3:
@@ -6698,6 +6880,11 @@ packages:
   /type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
+    dev: true
+
+  /type-fest@4.10.3:
+    resolution: {integrity: sha512-JLXyjizi072smKGGcZiAJDCNweT8J+AuRxmPZ1aG7TERg4ijx9REl8CNhbr36RV4qXqL1gO1FF9HL8OkVmmrsA==}
+    engines: {node: '>=16'}
     dev: true
 
   /type-is@1.6.18:

--- a/tbdex-js.code-workspace
+++ b/tbdex-js.code-workspace
@@ -1,0 +1,84 @@
+{
+  "folders": [
+    {
+      // Source root
+      "name": "root",
+      "path": "."
+    },
+    {
+      // @tbdex/protocol
+      "name": "protocol",
+      "path": "packages/protocol",
+    },
+    {
+      // @tbdex/http-client
+      "name": "http-client",
+      "path": "packages/http-client",
+    },
+    {
+      // @tbdex/http-server
+      "name": "http-server",
+      "path": "packages/http-server",
+    }
+  ],
+  "settings": {
+    "eslint.workingDirectories": [
+      {
+        "mode": "auto"
+      }
+    ],
+    "npm.packageManager": "pnpm",
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "always"
+    },
+    "typescript.tsdk": "root/node_modules/typescript/lib"
+  },
+  "launch": {
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Test All - Node",
+        "runtimeExecutable": "${workspaceFolder:root}/node_modules/.bin/mocha",
+        "runtimeArgs": [
+          "${workspaceFolder:root}/packages/**/tests/compiled/**/*.spec.js"
+        ],
+        "preLaunchTask": "build tests",
+        "console": "internalConsole",
+        "internalConsoleOptions": "openOnSessionStart",
+      }
+    ]
+  },
+  "tasks": {
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Build All",
+        "type": "shell",
+        "command": "pnpm build",
+        "problemMatcher": [],
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        }
+      },
+      {
+        "label": "build tests",
+        "type": "shell",
+        "command": "pnpm",
+        "args": [
+          "--recursive",
+          "--stream",
+          "build:tests:node"
+        ],
+        "problemMatcher": [
+          "$tsc"
+        ],
+        "options": {
+          "cwd": "${workspaceFolder:root}"
+        }
+      },
+    ]
+  }
+}


### PR DESCRIPTION
TL;DR I'm using `msw` to write tests, but I'm using `msw` weirdly, but I have good reasons.

## Draft Phrase Preamble
Before I dive in and write ~20 tests using this approach, I want to get some soft consensus that people like testing the http-client this way. I tried several different libraries for mocking `fetch` and testing `fetch` requests, and honestly don't like any of them, but I've settled on an approach that works for our use case.

## Overview
Our current tests in the http-client are brittle. We test that we can call methods like `TbdexHttpClient.sendMessage` to make sure that they do not `throw`, but we have no assertions that we are actually sending a message to the correct url with the correct request structure. The aim of this PR is to add those tests.

We select `msw` to accomplish this because `msw` has allows us to record requests to an endpoint and `msw` supports a wider variety of environments that other libraries.

## Testing libraries comparison
I'll start by saying I settled on `msw`, but deliberately going against some of its recommended best practices. More detail below.

### nock
I found nock the most ergonomic for setting up one-time request interceptors. Its API was exactly what I wanted. Sadly it has limited environment support, and I don't want to have to re-write all these tests again in a month when nock inevitably doesn't cut it.

### Polly.js
I had high hopes when I saw Netflix built it, but the docs are all over the place and it's pretty complex to set up. The [quickstart](https://netflix.github.io/pollyjs/#/quick-start) is broken and uses deprecated APIs, and finally saw that [the adapter I needed was built on top of `nock` anyway](https://netflix.github.io/pollyjs/#/adapters/node-http). 

### msw
**Rant**: I tried `msw` first, hated it, then came crawling back. I don't like that `msw` feels like reimplementing the server in the test files. I REALLY don't like having a separate `handlers.js` where all the default ~mocks~ request handlers go. [Kent C Dodds](https://kentcdodds.com/blog/stop-mocking-fetch) seems to love how short it makes his tests, but personally I find it hard to read what the test is actually testing for. 

To better accommodate ~my neuroses~ our use case, these tests deliberately go against some of MSW's officially recommended best practices. In particular, these tests make [request assertions](https://mswjs.io/docs/best-practices/avoid-request-assertions) . MSW's reasoning is that request assertions tend to test implementation rather than behavior. This makes sense for apps where one entity controls (and can freely make changes to) both the client and server. However, we are implementing a spec, and must be sure that our client adheres precisely to the spec in the requests' url, header, and body.

Though other libraries (e.g. nock) supply assertions for request url, header, and body matching out of the box, we choose MSW because it has support for a wide variety of environments. To adapt it for our use case, we make extensive use of `server.use(http.get({ once: true, ... }))` as a form of assertion.

