### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
 
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
 
+      - name: Set up Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+
       - name: Verify NPM token is authenticated with NPMjs.com
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Hack to fix the `npm whoami` cmd.

We need to follow up and understand why we are getting failures if we dont add the following block and rely entirely on Hermit.
```
      - name: Set up Node.js
        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
        with:
          node-version: 20
          registry-url: https://registry.npmjs.org/
```
