### PR TITLE
Set NPM Config Registry in .npmrc for the Release Workflow

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -41,12 +41,6 @@ jobs:
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
 
-      - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
-
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,9 @@ jobs:
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
 
-      - name: Set up Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
+      - name: Store NPM Registry Settings to .npmrc
+        run: |
+          echo -e "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > ~/.npmrc
 
       - name: Verify NPM token is authenticated with NPMjs.com
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ packages/**/src/try.ts
 
 # Test report
 results.xml
+
+# Hermit build output
+.hermit


### PR DESCRIPTION
This PR is removing the recent hack introduced on #198 where we needed to add the unnecessary `setup-node` action which overlaps with hermit.

What they do under the hood, which was also my fix, is just to create the `.npmrc` with the registry url stating that we will use the NODE_AUTH_TOKEN.

Also I've added the `.hermit` folder to git ignore to prevent adding it by mistake in the Version Packages PR.

Working Evidence: #202 