### PR TITLE
build and publish snapshot releases on every merge to main

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,0 +1,87 @@
+name: release snapshot to jfrog
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, but do NOT cancel in-progress runs as
+# we want to allow these release deployments to complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-npm:
+    name: Snapshot Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        with:
+          fetch-depth: 0
+          submodules: "true"
+
+      # https://cashapp.github.io/hermit/usage/ci/
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@31ce88b17a84941bb1b782f1b7b317856addf286 #v1.1.0
+        with:
+          cache: "true"
+
+      - uses: jfrog/setup-jfrog-cli@d82fe26823e1f25529250895d5673f65b02af085 #v4.0.1
+        with:
+          version: latest
+          oidc-provider-name: github # must match the OpenID Connect name from https://blockxyz.jfrog.io/ui/admin/configuration/integrations
+        env:
+          JF_URL: https://blockxyz.jfrog.io
+
+      - name: Publish snapshot
+        env:
+          REGISTRY: https://blockxyz.jfrog.io/artifactory/api/npm/tbd-oss-snapshots-npm/
+        run: |
+          set -exuo pipefail
+          cd packages/protocol
+
+          base_version=$(jq -r .version package.json)
+          commits_since_version_bump=$(git rev-list HEAD $(git describe --tags --abbrev=0 HEAD) --count)
+          latest_commit="$(git rev-parse HEAD)"
+
+          snapshot_version="${base_version}-SNAPSHOT.${commits_since_version_bump}-${latest_commit:0:7}"
+
+          # check if that snapshot version has already been published
+          if npm view --registry "${REGISTRY}" "@tbdex/protocol@${snapshot_version}" > /dev/null; then
+              echo "release for @tbdex/protocol@${snapshot_version} already exists, not re-publishing"
+              exit 0
+          fi
+
+          cd ../..
+          pnpm install
+          pnpm build
+
+          jf npm-config --global=true --repo-resolve=tbd-oss-snapshots-npm --repo-deploy=tbd-oss-snapshots-npm
+
+          for package in protocol http-client http-server; do
+            pushd "packages/${package}"
+
+            sed -i "s#workspace:\*#${snapshot_version}#g" package.json
+
+            # set the snapshot version
+            jq --arg version "${snapshot_version}" '.version = $version' package.json > package-new.json
+            mv package-new.json package.json
+
+            # set publishing config in package.json
+            jq --arg registry "${REGISTRY}" '.publishConfig.registry = $registry' package.json > package-new.json
+            mv package-new.json package.json
+
+            # login to jfrog and publish
+            jf npm publish --registry "${REGISTRY}"
+
+            popd
+          done
+        shell: bash

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -6,11 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-# Allow only one concurrent deployment, but do NOT cancel in-progress runs as
-# we want to allow these release deployments to complete.
+# Allow only one concurrent deployment
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -46,21 +44,13 @@ jobs:
           REGISTRY: https://blockxyz.jfrog.io/artifactory/api/npm/tbd-oss-snapshots-npm/
         run: |
           set -exuo pipefail
-          cd packages/protocol
 
-          base_version=$(jq -r .version package.json)
+          base_version=$(jq -r .version packages/protocol/package.json)
           commits_since_version_bump=$(git rev-list HEAD $(git describe --tags --abbrev=0 HEAD) --count)
-          latest_commit="$(git rev-parse HEAD)"
+          latest_commit="$(git rev-parse --short=7 HEAD)"
 
-          snapshot_version="${base_version}-SNAPSHOT.${commits_since_version_bump}-${latest_commit:0:7}"
+          snapshot_version="${base_version}-SNAPSHOT.${commits_since_version_bump}-${latest_commit}"
 
-          # check if that snapshot version has already been published
-          if npm view --registry "${REGISTRY}" "@tbdex/protocol@${snapshot_version}" > /dev/null; then
-              echo "release for @tbdex/protocol@${snapshot_version} already exists, not re-publishing"
-              exit 0
-          fi
-
-          cd ../..
           pnpm install
           pnpm build
 


### PR DESCRIPTION
This is part of a project being undertaken by OSP to help new code make it's way to TBD's downstream projects faster. It creates a snapshot release for each merge to main, which is published to our Artifactory* registry. Once this is done, downstream projects (developer.tbd.website) can pull in new tbdex-js features before a real release has been produced by depending on the snapshot version.

*Artifactory: behaves like npmjs.com, but isn't real npmjs.com so the high number of releases this creates will not spam up our npmjs.com page.