### PR TITLE
Feat/update gen test vectors

### DIFF
--- a/packages/protocol/tests/generate-test-vectors.ts
+++ b/packages/protocol/tests/generate-test-vectors.ts
@@ -13,19 +13,18 @@ type TestVector = {
   error: boolean
 }
 
-const pfiDid = await DidDht.create()
+const pfiDid = await DidDht.create({
+  options: {
+    services: [{
+      type            : 'PFI',
+      id              : 'pfi',
+      serviceEndpoint : 'https://localhost:9000'
+    }]
+  }
+})
 const aliceDid = await DidDht.create()
 
 const generateParseOfferingVector = async () => {
-  const pfiDid = await await DidDht.create({
-    options: {
-      services: [{
-        type            : 'PFI',
-        id              : 'pfi',
-        serviceEndpoint : 'https://localhost:9000'
-      }]
-    }
-  })
   const offering = DevTools.createOffering({ from: pfiDid.uri })
 
   await offering.sign(pfiDid)
@@ -39,7 +38,7 @@ const generateParseOfferingVector = async () => {
 }
 
 const generateParseQuoteVector = async () => {
-  const pfiDid = await DidDht.create()
+
   const quote = Quote.create({
     metadata: {
       exchangeId : Message.generateId('rfq'),
@@ -60,7 +59,6 @@ const generateParseQuoteVector = async () => {
 }
 
 const generateParseRfqVector = async () => {
-  const aliceDid = await DidDht.create()
   const vc = await VerifiableCredential.create({
     type    : 'PuupuuCredential',
     issuer  : aliceDid.uri,
@@ -107,7 +105,6 @@ const generateParseRfqVector = async () => {
 }
 
 const generateParseOrderVector = async () => {
-  const aliceDid = await DidDht.create()
   const order = Order.create({
     metadata: { from: aliceDid.uri, to: pfiDid.uri, exchangeId: Message.generateId('rfq'), externalId: 'ext_1234',  protocol: '1.0' }
   })
@@ -123,7 +120,6 @@ const generateParseOrderVector = async () => {
 }
 
 const generateParseCloseVector = async () => {
-  const pfiDid = await DidDht.create()
   const close = Close.create({
     metadata : { from: pfiDid.uri, to: aliceDid.uri, exchangeId: Message.generateId('rfq'),  protocol: '1.0' },
     data     : {
@@ -142,7 +138,6 @@ const generateParseCloseVector = async () => {
 }
 
 const generateParseOrderStatusVector = async () => {
-  const pfiDid = await DidDht.create()
   const orderStatus = OrderStatus.create({
     metadata : { from: pfiDid.uri, to: aliceDid.uri, exchangeId: Message.generateId('rfq'),  protocol: '1.0' },
     data     : {


### PR DESCRIPTION
Updating the `generate-test-vectors` script so that pfis always have a pfi service endpoint. The test vectors that are generated from this script produce vectors that fail validation when expected to get a pfi service endpoint.