### PR TITLE
Patch provenance config

### DIFF
--- a/.changeset/blue-shirts-love.md
+++ b/.changeset/blue-shirts-love.md
@@ -1,0 +1,7 @@
+---
+"@tbdex/http-client": patch
+"@tbdex/http-server": patch
+"@tbdex/protocol": patch
+---
+
+Add provenance config to the build


### PR DESCRIPTION
In case we really can't republish under 1.0.0 with provenance I'm bumping here to get the 1.0.1 out with provenance