### PR TITLE
Boosted http-client code coverage to 100% + minor updates

### DIFF
--- a/packages/http-client/.c8rc.json
+++ b/packages/http-client/.c8rc.json
@@ -14,6 +14,7 @@
   ],
   "reporter": [
     "cobertura",
+    "html",
     "text"
   ]
 }

--- a/packages/http-client/src/client.ts
+++ b/packages/http-client/src/client.ts
@@ -148,7 +148,7 @@ export class TbdexHttpClient {
       throw new RequestError({ message: `Failed to get offerings from ${pfiDid}`, recipientDid: pfiDid, url: apiRoute, cause: e })
     }
 
-    const data: Offering[] = []
+    const offerings: Offering[] = []
 
     if (!response.ok) {
       const errorDetails = await response.json() as ErrorDetail[]
@@ -159,10 +159,10 @@ export class TbdexHttpClient {
     const jsonOfferings = responseBody.data as any[]
     for (let jsonOffering of jsonOfferings) {
       const offering = await Offering.parse(jsonOffering)
-      data.push(offering)
+      offerings.push(offering)
     }
 
-    return data
+    return offerings
   }
 
   /**
@@ -221,7 +221,7 @@ export class TbdexHttpClient {
       throw new RequestError({ message: `Failed to get exchange from ${pfiDid}`, recipientDid: pfiDid, url: apiRoute, cause: e })
     }
 
-    const data: Message[] = []
+    const messages: Message[] = []
 
     if (!response.ok) {
       const errorDetails = await response.json() as ErrorDetail[]
@@ -231,17 +231,17 @@ export class TbdexHttpClient {
     const responseBody = await response.json() as { data: MessageModel[] }
     for (let jsonMessage of responseBody.data) {
       const message = await Parser.parseMessage(jsonMessage)
-      data.push(message)
+      messages.push(message)
     }
 
-    return data
+    return messages
 
   }
 
   // TODO: Wrap Message[] in Exchange object and verify each message
   /**
    * returns all exchanges created by requester
-   * @param _opts - options
+   * @param opts - options
    */
   static async getExchanges(opts: GetExchangesOptions): Promise<Message[][]> {
     const { pfiDid, filter, did } = opts

--- a/packages/http-client/src/client.ts
+++ b/packages/http-client/src/client.ts
@@ -427,8 +427,11 @@ export type GetExchangeOptions = {
 export type GetExchangesOptions = {
   /** the DID of the PFI from whom you want to get offerings */
   pfiDid: string
+  /** the message author's DID */
   did: BearerDid,
+  /** the filter to select the desired exchanges */
   filter?: {
+    /** ID or IDs of exchanges to get */
     id: string | string[]
   }
 }

--- a/packages/http-client/src/errors/request-error.ts
+++ b/packages/http-client/src/errors/request-error.ts
@@ -25,7 +25,5 @@ export class RequestError extends Error {
     this.name = this.constructor.name
     this.recipientDid = params.recipientDid
     this.url = params.url
-
-    Object.setPrototypeOf(this, RequestError.prototype)
   }
 }

--- a/packages/http-client/src/errors/request-token-error.ts
+++ b/packages/http-client/src/errors/request-token-error.ts
@@ -18,8 +18,6 @@ export class RequestTokenError extends Error {
     super(params.message, { cause: params.cause })
 
     this.name = this.constructor.name
-
-    Object.setPrototypeOf(this, RequestTokenError.prototype)
   }
 }
 
@@ -27,58 +25,28 @@ export class RequestTokenError extends Error {
    * Error thrown when a request token cannot be signed
    * @beta
    */
-export class RequestTokenSigningError extends RequestTokenError {
-  constructor(params: RequestTokenErrorParams) {
-    super(params)
-
-    Object.setPrototypeOf(this, RequestTokenSigningError.prototype)
-  }
-}
+export class RequestTokenSigningError extends RequestTokenError { }
 
 /**
    * Error thrown when a request token cannot be verified
    * @beta
    */
-export class RequestTokenVerificationError extends RequestTokenError {
-  constructor(params: RequestTokenErrorParams) {
-    super(params)
-
-    Object.setPrototypeOf(this, RequestTokenVerificationError.prototype)
-  }
-}
+export class RequestTokenVerificationError extends RequestTokenError { }
 
 /**
    * Error thrown when a request token is missing required claims
    * @beta
    */
-export class RequestTokenMissingClaimsError extends RequestTokenError {
-  constructor(params: RequestTokenErrorParams) {
-    super(params)
-
-    Object.setPrototypeOf(this, RequestTokenMissingClaimsError.prototype)
-  }
-}
+export class RequestTokenMissingClaimsError extends RequestTokenError { }
 
 /**
    * Error thrown when a request token aud does not match the PFI did for which its intended
    * @beta
    */
-export class RequestTokenAudienceMismatchError extends RequestTokenError {
-  constructor(params: RequestTokenErrorParams) {
-    super(params)
-
-    Object.setPrototypeOf(this, RequestTokenAudienceMismatchError.prototype)
-  }
-}
+export class RequestTokenAudienceMismatchError extends RequestTokenError { }
 
 /**
    * Error thrown when a request token payload iss does not match request token header kid
    * @beta
    */
-export class RequestTokenIssuerSignerMismatchError extends RequestTokenError {
-  constructor(params: RequestTokenErrorParams) {
-    super(params)
-
-    Object.setPrototypeOf(this, RequestTokenIssuerSignerMismatchError.prototype)
-  }
-}
+export class RequestTokenIssuerSignerMismatchError extends RequestTokenError { }

--- a/packages/http-client/src/errors/response-error.ts
+++ b/packages/http-client/src/errors/response-error.ts
@@ -37,7 +37,5 @@ export class ResponseError extends Error {
     this.details = params.details
     this.recipientDid = params.recipientDid
     this.url = params.url
-
-    Object.setPrototypeOf(this, ResponseError.prototype)
   }
 }

--- a/packages/http-client/src/errors/validation-error.ts
+++ b/packages/http-client/src/errors/validation-error.ts
@@ -11,8 +11,6 @@ export class ValidationError extends Error {
     super(message)
 
     this.name = this.constructor.name
-
-    Object.setPrototypeOf(this, ValidationError.prototype)
   }
 }
 
@@ -20,22 +18,10 @@ export class ValidationError extends Error {
  * Error thrown when a DID is invalid
  * @beta
  */
-export class InvalidDidError extends ValidationError {
-  constructor(message: string) {
-    super(message)
-
-    Object.setPrototypeOf(this, InvalidDidError.prototype)
-  }
-}
+export class InvalidDidError extends ValidationError { }
 
 /**
  * Error thrown when a PFI's service endpoint can't be found
  * @beta
  */
-export class MissingServiceEndpointError extends ValidationError {
-  constructor(message: string) {
-    super(message)
-
-    Object.setPrototypeOf(this, MissingServiceEndpointError.prototype)
-  }
-}
+export class MissingServiceEndpointError extends ValidationError { }

--- a/packages/http-client/tests/client.spec.ts
+++ b/packages/http-client/tests/client.spec.ts
@@ -486,25 +486,24 @@ describe('client', () => {
 
     it('returns array of message exchanges given a list of exchange IDs', async () => {
       const alice = await DidJwk.create()
-      const aliceRfq = await DevTools.createRfq({ sender: alice })
-      await aliceRfq.sign(alice)
+      const aliceRfq1 = await DevTools.createRfq({ sender: alice })
+      await aliceRfq1.sign(alice)
 
-      const bob = await DidJwk.create()
-      const bobRfq = await DevTools.createRfq({ sender: bob })
-      await bobRfq.sign(bob)
+      const aliceRfq2 = await DevTools.createRfq({ sender: alice })
+      await aliceRfq2.sign(alice)
 
       fetchStub.resolves({
         ok   : true,
         json : () => Promise.resolve({ data: [
-          [aliceRfq.toJSON()],
-          [bobRfq.toJSON()]
+          [aliceRfq1.toJSON()],
+          [aliceRfq2.toJSON()]
         ] })
       } as Response)
 
       const exchanges = await TbdexHttpClient.getExchanges({
         pfiDid : pfiDid.uri,
-        did    : pfiDid,
-        filter : { id: [aliceRfq.metadata.id, bobRfq.metadata.id]}
+        did    : alice,
+        filter : { id: [aliceRfq1.metadata.id, aliceRfq2.metadata.id]}
       })
       expect(exchanges).to.have.length(2)
     })

--- a/packages/http-client/tests/client.spec.ts
+++ b/packages/http-client/tests/client.spec.ts
@@ -11,7 +11,7 @@ import {
   RequestTokenSigningError,
   RequestTokenIssuerSignerMismatchError
 } from '../src/errors/index.js'
-import { DevTools, Offering } from '@tbdex/protocol'
+import { DevTools } from '@tbdex/protocol'
 import * as sinon from 'sinon'
 import { JwtHeaderParams, JwtPayload } from '@web5/crypto'
 import { Convert } from '@web5/common'
@@ -496,15 +496,15 @@ describe('client', () => {
       fetchStub.resolves({
         ok   : true,
         json : () => Promise.resolve({ data: [
-          [aliceRfq.toJSON()], 
+          [aliceRfq.toJSON()],
           [bobRfq.toJSON()]
         ] })
       } as Response)
 
       const exchanges = await TbdexHttpClient.getExchanges({
-        pfiDid: pfiDid.uri,
-        did: pfiDid,
-        filter: { id: [aliceRfq.metadata.id, bobRfq.metadata.id]}
+        pfiDid : pfiDid.uri,
+        did    : pfiDid,
+        filter : { id: [aliceRfq.metadata.id, bobRfq.metadata.id]}
       })
       expect(exchanges).to.have.length(2)
     })

--- a/packages/http-client/tests/error.spec.ts
+++ b/packages/http-client/tests/error.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai'
+import {
+  RequestTokenMissingClaimsError,
+  RequestTokenSigningError,
+  RequestTokenError
+} from '../src/main.js'
+
+describe('Custom error class', () => {
+    it('has expected inheritance prototype chain', async () => {
+        const error = new RequestTokenSigningError({ message: 'any message' })
+        expect(error).to.be.instanceOf(Error)
+        expect(error).to.be.instanceOf(RequestTokenError)
+        expect(error).to.be.instanceOf(RequestTokenSigningError)
+        expect(error).to.not.be.instanceOf(RequestTokenMissingClaimsError)
+    })
+})

--- a/packages/http-client/tests/error.spec.ts
+++ b/packages/http-client/tests/error.spec.ts
@@ -6,11 +6,11 @@ import {
 } from '../src/main.js'
 
 describe('Custom error class', () => {
-    it('has expected inheritance prototype chain', async () => {
-        const error = new RequestTokenSigningError({ message: 'any message' })
-        expect(error).to.be.instanceOf(Error)
-        expect(error).to.be.instanceOf(RequestTokenError)
-        expect(error).to.be.instanceOf(RequestTokenSigningError)
-        expect(error).to.not.be.instanceOf(RequestTokenMissingClaimsError)
-    })
+  it('has expected inheritance prototype chain', async () => {
+    const error = new RequestTokenSigningError({ message: 'any message' })
+    expect(error).to.be.instanceOf(Error)
+    expect(error).to.be.instanceOf(RequestTokenError)
+    expect(error).to.be.instanceOf(RequestTokenSigningError)
+    expect(error).to.not.be.instanceOf(RequestTokenMissingClaimsError)
+  })
 })

--- a/packages/http-server/.c8rc.json
+++ b/packages/http-server/.c8rc.json
@@ -14,6 +14,7 @@
   ],
   "reporter": [
     "cobertura",
+    "html",
     "text"
   ]
 }

--- a/packages/http-server/src/callback-error.ts
+++ b/packages/http-server/src/callback-error.ts
@@ -22,7 +22,5 @@ export class CallbackError extends Error {
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor)
     }
-
-    Object.setPrototypeOf(this, CallbackError.prototype)
   }
 }

--- a/packages/protocol/.c8rc.json
+++ b/packages/protocol/.c8rc.json
@@ -13,6 +13,7 @@
   ],
   "reporter": [
     "cobertura",
+    "html",
     "text"
   ]
 }


### PR DESCRIPTION
- Boosted `http-client` to have 100% code coverage
- Removed seemingly unnecessary explicit calls of `setPrototypeOf()`
- Added `html` reporter for code coverage for local detailed report