### PR TITLE
Fixed bug where IDs passed to getExchanges is handled incorrectly

### DIFF
--- a/.changeset/fair-spiders-eat.md
+++ b/.changeset/fair-spiders-eat.md
@@ -2,4 +2,4 @@
 "@tbdex/http-server": patch
 ---
 
-Fixed bug where IDs passed to getExchanges is handled incorrectly.
+Fixed bugs in tests involving calledWith() and increased code coverage.

--- a/.changeset/fair-spiders-eat.md
+++ b/.changeset/fair-spiders-eat.md
@@ -1,0 +1,5 @@
+---
+"@tbdex/http-server": patch
+---
+
+Fixed bug where IDs passed to getExchanges is handled incorrectly.

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -41,6 +41,7 @@
     "@types/sinon": "^17.0.3",
     "@types/sinon-chai": "^3.2.12",
     "chai": "4.3.10",
+    "query-string": "8.2.0",
     "rimraf": "5.0.1",
     "sinon": "17.0.1",
     "sinon-chai": "3.7.0",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -39,9 +39,11 @@
     "@types/mocha": "10.0.1",
     "@types/node": "20.9.4",
     "@types/sinon": "^17.0.3",
+    "@types/sinon-chai": "^3.2.12",
     "chai": "4.3.10",
     "rimraf": "5.0.1",
     "sinon": "17.0.1",
+    "sinon-chai": "3.7.0",
     "supertest": "6.3.3",
     "typescript": "5.2.2"
   },

--- a/packages/http-server/src/request-handlers/get-exchanges.ts
+++ b/packages/http-server/src/request-handlers/get-exchanges.ts
@@ -39,8 +39,9 @@ export async function getExchanges(request: Request, response: Response, opts: G
   }
 
   if (request.query.id !== undefined) {
-    if (Array.isArray(request.query.id)) {
-      queryParams.id = request.query.id.map((id) => id.toString())
+    const idQueryParam = JSON.parse(request.query.id.toString())
+    if (Array.isArray(idQueryParam)) {
+      queryParams.id = idQueryParam.map((id) => id.toString())
     } else {
       queryParams.id = [request.query.id.toString()]
     }

--- a/packages/http-server/src/request-handlers/get-exchanges.ts
+++ b/packages/http-server/src/request-handlers/get-exchanges.ts
@@ -39,9 +39,8 @@ export async function getExchanges(request: Request, response: Response, opts: G
   }
 
   if (request.query.id !== undefined) {
-    const idQueryParam = JSON.parse(request.query.id.toString())
-    if (Array.isArray(idQueryParam)) {
-      queryParams.id = idQueryParam.map((id) => id.toString())
+    if (Array.isArray(request.query.id)) {
+      queryParams.id = request.query.id.map((id) => id.toString())
     } else {
       queryParams.id = [request.query.id.toString()]
     }

--- a/packages/http-server/tests/get-exchange.spec.ts
+++ b/packages/http-server/tests/get-exchange.spec.ts
@@ -1,11 +1,15 @@
 import type { Server } from 'http'
 import Sinon, * as sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import chai from 'chai'
 
 import { TbdexHttpServer, RequestContext } from '../src/main.js'
 import { BearerDid, DidDht, DidJwk } from '@web5/dids'
 import { expect } from 'chai'
 import { InMemoryExchangesApi } from '../src/in-memory-exchanges-api.js'
 import { DevTools, ErrorDetail, TbdexHttpClient } from '@tbdex/http-client'
+
+chai.use(sinonChai)
 
 describe('GET /exchanges', () => {
   let server: Server
@@ -112,9 +116,9 @@ describe('GET /exchanges', () => {
 
     expect(resp.ok).to.be.true
     expect(exchangesApiSpy.calledOnce).to.be.true
-    expect(exchangesApiSpy.calledWith({
+    expect(exchangesApiSpy).to.have.been.calledWith({
       id: exchangeId,
-    })).to.be.true
+    })
 
     exchangesApiSpy.restore()
   })

--- a/packages/http-server/tests/get-exchanges.spec.ts
+++ b/packages/http-server/tests/get-exchanges.spec.ts
@@ -1,5 +1,6 @@
 import type { Server } from 'http'
 import Sinon, * as sinon from 'sinon'
+import queryString from 'query-string'
 import sinonChai from 'sinon-chai'
 import chai from 'chai'
 
@@ -114,17 +115,16 @@ describe('GET /exchanges', () => {
       exchangesApiSpy.restore()
     })
 
-    it('passes the id array query param as an array to the filter of ExchangesApi.getExchanges', async () => {
+    it.only('passes the id array query param as an array to the filter of ExchangesApi.getExchanges', async () => {
       const alice = await DidJwk.create()
 
       const exchangesApiSpy = sinon.spy(api.exchangesApi, 'getExchanges')
 
       const requestToken = await TbdexHttpClient.generateRequestToken({ requesterDid: alice, pfiDid: api.pfiDid })
 
-      // `id` query param contains an array
-      const idQueryParam = ['1234', '5678']
-      const idQueryParamString = JSON.stringify(idQueryParam) // '["1234","5678"]'
-      const resp = await fetch(`http://localhost:8000/exchanges?id=${idQueryParamString}`, {
+      const queryParams = { id: ['1234', '5678'] }
+      const queryParamsString = queryString.stringify(queryParams)
+      const resp = await fetch(`http://localhost:8000/exchanges?${queryParamsString}`, {
         headers: {
           'Authorization': `Bearer ${requestToken}`
         }
@@ -133,8 +133,8 @@ describe('GET /exchanges', () => {
       expect(resp.ok).to.be.true
       expect(exchangesApiSpy).to.have.been.calledWith({
         filter: {
-          from : alice.uri,
-          id   : idQueryParam
+          from: alice.uri,
+          ...queryParams
         }
       })
 

--- a/packages/http-server/tests/get-exchanges.spec.ts
+++ b/packages/http-server/tests/get-exchanges.spec.ts
@@ -1,11 +1,15 @@
 import type { Server } from 'http'
 import Sinon, * as sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import chai from 'chai'
 
 import { TbdexHttpServer, RequestContext, GetExchangesFilter } from '../src/main.js'
 import { DidJwk } from '@web5/dids'
 import { expect } from 'chai'
 import { InMemoryExchangesApi } from '../src/in-memory-exchanges-api.js'
 import { DevTools, ErrorDetail, TbdexHttpClient } from '@tbdex/http-client'
+
+chai.use(sinonChai)
 
 describe('GET /exchanges', () => {
   let server: Server
@@ -74,11 +78,11 @@ describe('GET /exchanges', () => {
 
       expect(resp.ok).to.be.true
       expect(exchangesApiSpy.calledOnce).to.be.true
-      expect(exchangesApiSpy.calledWith({
+      expect(exchangesApiSpy).to.have.been.calledWith({
         filter: {
           from: alice.uri
         }
-      })).to.be.true
+      })
 
       exchangesApiSpy.restore()
     })
@@ -100,12 +104,12 @@ describe('GET /exchanges', () => {
 
       expect(resp.ok).to.be.true
       expect(exchangesApiSpy.calledOnce).to.be.true
-      expect(exchangesApiSpy.calledWith({
+      expect(exchangesApiSpy).to.have.been.calledWith({
         filter: {
           from : alice.uri,
           id   : [idQueryParam]
         }
-      }))
+      })
 
       exchangesApiSpy.restore()
     })
@@ -119,20 +123,20 @@ describe('GET /exchanges', () => {
 
       // `id` query param contains an array
       const idQueryParam = ['1234', '5678']
-      const resp = await fetch(`http://localhost:8000/exchanges?id=[${idQueryParam.join(',')}]`, {
+      const idQueryParamString = JSON.stringify(idQueryParam) // '["1234","5678"]'
+      const resp = await fetch(`http://localhost:8000/exchanges?id=${idQueryParamString}`, {
         headers: {
           'Authorization': `Bearer ${requestToken}`
         }
       })
 
       expect(resp.ok).to.be.true
-      expect(exchangesApiSpy.calledOnce).to.be.true
-      expect(exchangesApiSpy.calledWith({
+      expect(exchangesApiSpy).to.have.been.calledWith({
         filter: {
           from : alice.uri,
           id   : idQueryParam
         }
-      }))
+      })
 
       exchangesApiSpy.restore()
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       '@types/sinon':
         specifier: ^17.0.3
         version: 17.0.3
+      '@types/sinon-chai':
+        specifier: ^3.2.12
+        version: 3.2.12
       chai:
         specifier: 4.3.10
         version: 4.3.10
@@ -202,6 +205,9 @@ importers:
       sinon:
         specifier: 17.0.1
         version: 17.0.1
+      sinon-chai:
+        specifier: 3.7.0
+        version: 3.7.0(chai@4.3.10)(sinon@17.0.1)
       supertest:
         specifier: 6.3.3
         version: 6.3.3
@@ -1446,6 +1452,13 @@ packages:
       '@types/http-errors': 2.0.4
       '@types/mime': 4.0.0
       '@types/node': 20.9.4
+    dev: true
+
+  /@types/sinon-chai@3.2.12:
+    resolution: {integrity: sha512-9y0Gflk3b0+NhQZ/oxGtaAJDvRywCa5sIyaVnounqLvmf93yBF4EgIRspePtkMs3Tr844nCclYMlcCNmLCvjuQ==}
+    dependencies:
+      '@types/chai': 4.3.6
+      '@types/sinon': 17.0.3
     dev: true
 
   /@types/sinon@17.0.1:
@@ -6357,6 +6370,16 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+    dev: true
+
+  /sinon-chai@3.7.0(chai@4.3.10)(sinon@17.0.1):
+    resolution: {integrity: sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==}
+    peerDependencies:
+      chai: ^4.0.0
+      sinon: '>=4.0.0'
+    dependencies:
+      chai: 4.3.10
+      sinon: 17.0.1
     dev: true
 
   /sinon@17.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       chai:
         specifier: 4.3.10
         version: 4.3.10
+      query-string:
+        specifier: 8.2.0
+        version: 8.2.0
       rimraf:
         specifier: 5.0.1
         version: 5.0.1
@@ -3089,7 +3092,6 @@ packages:
   /decode-uri-component@0.4.1:
     resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
     engines: {node: '>=14.16'}
-    dev: false
 
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
@@ -3767,7 +3769,6 @@ packages:
   /filter-obj@5.1.0:
     resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
     engines: {node: '>=14.16'}
-    dev: false
 
   /finalhandler@1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
@@ -5924,7 +5925,6 @@ packages:
       decode-uri-component: 0.4.1
       filter-obj: 5.1.0
       split-on-first: 3.0.0
-    dev: false
 
   /querystring-es3@0.2.1:
     resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
@@ -6485,7 +6485,6 @@ packages:
   /split-on-first@3.0.0:
     resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
     engines: {node: '>=12'}
-    dev: false
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}


### PR DESCRIPTION
1. Fixed bug where IDs passed to getExchanges is handled incorrectly thus you cannot get exchanges given a list of IDs
2. Fixed bug in the test that is meant to test this (it always passes due to incorrect usage)
3. Fixed same issue in another test, switched to `sinon-chai` to give better readability and debug error message
4. 100% code coverage on `create-exchange.ts`