### PR TITLE
Removed query params for List Exchanges API

### DIFF
--- a/.changeset/modern-bobcats-ring.md
+++ b/.changeset/modern-bobcats-ring.md
@@ -1,0 +1,5 @@
+---
+"@tbdex/http-server": minor
+---
+
+Deprecated query params for List Exchanges API

--- a/packages/http-server/src/in-memory-exchanges-api.ts
+++ b/packages/http-server/src/in-memory-exchanges-api.ts
@@ -24,25 +24,14 @@ export class InMemoryExchangesApi implements ExchangesApi {
     }
 
     const exchanges: Exchange[] = []
-    if (opts.filter.id) {
-      // filter has `id` and `from`
-
-      for (const id of opts.filter.id) {
-        const exchange = this.exchangeMessagesMap.get(id)
-        if (exchange?.rfq?.from === opts.filter.from) {
-          exchanges.push(exchange)
-        }
+    // filter only has `from`
+    this.exchangeMessagesMap.forEach((exchange, _id) => {
+      // You definitely shouldn't use InMemoryExchangesApi in production.
+      // This will get really slow
+      if (exchange?.rfq?.from === opts.filter.from) {
+        exchanges.push(exchange)
       }
-    } else {
-      // filter only has `from`
-      this.exchangeMessagesMap.forEach((exchange, _id) => {
-        // You definitely shouldn't use InMemoryExchangesApi in production.
-        // This will get really slow
-        if (exchange?.rfq?.from === opts.filter.from) {
-          exchanges.push(exchange)
-        }
-      })
-    }
+    })
 
     return exchanges
   }

--- a/packages/http-server/src/request-handlers/get-exchanges.ts
+++ b/packages/http-server/src/request-handlers/get-exchanges.ts
@@ -34,24 +34,16 @@ export async function getExchanges(request: Request, response: Response, opts: G
     return
   }
 
-  const queryParams: GetExchangesFilter = {
+  const filter: GetExchangesFilter = {
     from: requesterDid,
   }
 
-  if (request.query.id !== undefined) {
-    if (Array.isArray(request.query.id)) {
-      queryParams.id = request.query.id.map((id) => id.toString())
-    } else {
-      queryParams.id = [request.query.id.toString()]
-    }
-  }
-
-  const exchanges = await exchangesApi.getExchanges({ filter: queryParams })
+  const exchanges = await exchangesApi.getExchanges({ filter })
 
   if (callback) {
     // TODO: figure out what to do with callback result. should we pass through the exchanges we've fetched
     //       and allow the callback to modify what's returned? (issue #10)
-    const _result = await callback({ request, response }, queryParams)
+    const _result = await callback({ request, response }, filter)
   }
 
   const data: Message[][] = exchanges.map(exchange => exchange.messages)

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -55,8 +55,6 @@ export type SubmitMessageCallback = SubmitOrderCallback | SubmitCloseCallback
  * @beta
  */
 export type GetExchangesFilter = {
-  /** List of exchanges ids */
-  id?: string[]
   /** the rfq author's DID */
   from: string
 }

--- a/packages/http-server/tests/get-exchanges.spec.ts
+++ b/packages/http-server/tests/get-exchanges.spec.ts
@@ -1,6 +1,5 @@
 import type { Server } from 'http'
 import Sinon, * as sinon from 'sinon'
-import queryString from 'query-string'
 import sinonChai from 'sinon-chai'
 import chai from 'chai'
 

--- a/packages/http-server/tests/get-exchanges.spec.ts
+++ b/packages/http-server/tests/get-exchanges.spec.ts
@@ -87,59 +87,6 @@ describe('GET /exchanges', () => {
 
       exchangesApiSpy.restore()
     })
-
-    it('passes the id non-array query param as an array to the filter of ExchangesApi.getExchanges', async () => {
-      const alice = await DidJwk.create()
-
-      const exchangesApiSpy = sinon.spy(api.exchangesApi, 'getExchanges')
-
-      const requestToken = await TbdexHttpClient.generateRequestToken({ requesterDid: alice, pfiDid: api.pfiDid })
-
-      // `id` query param contains a single string
-      const idQueryParam = '1234'
-      const resp = await fetch(`http://localhost:8000/exchanges?id=${idQueryParam}`, {
-        headers: {
-          'Authorization': `Bearer ${requestToken}`
-        }
-      })
-
-      expect(resp.ok).to.be.true
-      expect(exchangesApiSpy.calledOnce).to.be.true
-      expect(exchangesApiSpy).to.have.been.calledWith({
-        filter: {
-          from : alice.uri,
-          id   : [idQueryParam]
-        }
-      })
-
-      exchangesApiSpy.restore()
-    })
-
-    it.only('passes the id array query param as an array to the filter of ExchangesApi.getExchanges', async () => {
-      const alice = await DidJwk.create()
-
-      const exchangesApiSpy = sinon.spy(api.exchangesApi, 'getExchanges')
-
-      const requestToken = await TbdexHttpClient.generateRequestToken({ requesterDid: alice, pfiDid: api.pfiDid })
-
-      const queryParams = { id: ['1234', '5678'] }
-      const queryParamsString = queryString.stringify(queryParams)
-      const resp = await fetch(`http://localhost:8000/exchanges?${queryParamsString}`, {
-        headers: {
-          'Authorization': `Bearer ${requestToken}`
-        }
-      })
-
-      expect(resp.ok).to.be.true
-      expect(exchangesApiSpy).to.have.been.calledWith({
-        filter: {
-          from: alice.uri,
-          ...queryParams
-        }
-      })
-
-      exchangesApiSpy.restore()
-    })
   })
 
   it('calls the callback if it is provided', async () => {


### PR DESCRIPTION
Follow up for https://github.com/TBD54566975/tbdex/issues/312 to remove the query params.

Will also update the API implementation to return just the IDs as per #239 in a follow up PR.