### PR TITLE
#252 - Fixed long running parsing tests due to DID resolution

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-* @michaelneale @mistermoe @jiyoontbd @phoebe-lew @KendallWeihe @kirahsapong @diehuxx @thehenrytsai
+* @michaelneale @mistermoe @jiyoontbd @KendallWeihe @kirahsapong @diehuxx @thehenrytsai @nitro-neal
 
 
 # -----------------------------------------------

--- a/packages/protocol/tests/test-vectors.spec.ts
+++ b/packages/protocol/tests/test-vectors.spec.ts
@@ -7,19 +7,38 @@ import ParseQuote from '../../../tbdex/hosted/test-vectors/protocol/vectors/pars
 import ParseRfq from '../../../tbdex/hosted/test-vectors/protocol/vectors/parse-rfq.json' assert { type: 'json' }
 import ParseOmitPrivateData from '../../../tbdex/hosted/test-vectors/protocol/vectors/parse-rfq-omit-private-data.json' assert { type: 'json' }
 import ParseBalance from '../../../tbdex/hosted/test-vectors/protocol/vectors/parse-balance.json' assert { type: 'json' }
-import { Balance, Close, Offering, Order, OrderStatus, Quote, Rfq } from '../src/main.js'
+import { Balance, Close, Message, Offering, Order, OrderStatus, Quote, Resource, Rfq } from '../src/main.js'
 import { Parser } from '../src/parser.js'
+import Sinon from 'sinon'
 
 describe('TbdexTestVectorsProtocol', function () {
-  this.timeout(10000)
+  let messageVerifyStub: Sinon.SinonStub;
+  let resourceVerifyStub: Sinon.SinonStub;
+
+  beforeEach(function() {
+    // Our intent here is to test the overall parsing logic,
+    // so stub the signature verify methods to avoid real DID resolution over the network which can take more than 10 seconds for DID DHT
+    messageVerifyStub = Sinon.stub(Message.prototype, 'verify');
+    resourceVerifyStub = Sinon.stub(Resource.prototype, 'verify');
+  });
+
+  afterEach(function() {
+    // Restore the original method
+    messageVerifyStub.restore();
+    resourceVerifyStub.restore();
+  });
+
   it('parse_close', async () => {
     // Parse with parseMessage()
     const message = await Parser.parseMessage(ParseClose.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(message.isClose()).to.be.true
     expect(message.toJSON()).to.deep.eq(ParseClose.output)
+    messageVerifyStub.resetHistory()
 
     // Parse with Close.parse()
     const close = await Close.parse(ParseClose.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(close.isClose()).to.be.true
     expect(close.toJSON()).to.deep.eq(ParseClose.output)
   })
@@ -27,11 +46,14 @@ describe('TbdexTestVectorsProtocol', function () {
   it('parse_offering', async() => {
     // Parse with parseResource()
     const resource = await Parser.parseResource(ParseOffering.input)
+    expect(resourceVerifyStub.calledOnce).to.be.true
     expect(resource.isOffering()).to.be.true
     expect(resource.toJSON()).to.deep.eq(ParseOffering.output)
+    resourceVerifyStub.resetHistory()
 
     // Parse with Offering.parse()
     const offering = await Offering.parse(ParseOffering.input)
+    expect(resourceVerifyStub.calledOnce).to.be.true
     expect(offering.isOffering()).to.be.true
     expect(offering.toJSON()).to.deep.eq(ParseOffering.output)
   })
@@ -39,11 +61,14 @@ describe('TbdexTestVectorsProtocol', function () {
   it('parse_order', async () => {
     // Parse with parseMessage()
     const message = await Parser.parseMessage(ParseOrder.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(message.isOrder()).to.be.true
     expect(message.toJSON()).to.deep.eq(ParseOrder.output)
+    messageVerifyStub.resetHistory()
 
     // Parse with Order.parse()
     const order = await Order.parse(ParseOrder.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(order.isOrder()).to.be.true
     expect(order.toJSON()).to.deep.eq(ParseOrder.output)
   })
@@ -51,11 +76,14 @@ describe('TbdexTestVectorsProtocol', function () {
   it('parse_orderstatus', async () => {
     // Parse with parseMessage()
     const message = await Parser.parseMessage(ParseOrderStatus.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(message.isOrderStatus()).to.be.true
     expect(message.toJSON()).to.deep.eq(ParseOrderStatus.output)
+    messageVerifyStub.resetHistory()
 
     // Parse with OrderStatus.parse()
     const orderstatus = await OrderStatus.parse(ParseOrderStatus.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(orderstatus.isOrderStatus()).to.be.true
     expect(orderstatus.toJSON()).to.deep.eq(ParseOrderStatus.output)
   })
@@ -63,11 +91,14 @@ describe('TbdexTestVectorsProtocol', function () {
   it('parse_quote', async () => {
     // Parse with parseMessage()
     const message = await Parser.parseMessage(ParseQuote.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(message.isQuote()).to.be.true
     expect(message.toJSON()).to.deep.eq(ParseQuote.output)
+    messageVerifyStub.resetHistory()
 
     // Parse with Quote.parse()
     const quote = await Quote.parse(ParseQuote.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(quote.isQuote()).to.be.true
     expect(quote.toJSON()).to.deep.eq(ParseQuote.output)
   })
@@ -75,11 +106,14 @@ describe('TbdexTestVectorsProtocol', function () {
   it('parse_rfq', async () => {
     // Parse with parseMessage()
     const message = await Parser.parseMessage(ParseRfq.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(message.isRfq()).to.be.true
     expect(message.toJSON()).to.deep.eq(ParseRfq.output)
+    messageVerifyStub.resetHistory()
 
     // Parse with Rfq.parse()
     const rfq = await Rfq.parse(ParseRfq.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(rfq.isRfq()).to.be.true
     expect(rfq.toJSON()).to.deep.eq(ParseRfq.output)
   })
@@ -87,11 +121,14 @@ describe('TbdexTestVectorsProtocol', function () {
   it('parse_rfq_omit_private_data', async () => {
     // Parse with parseMessage()
     const message = await Parser.parseMessage(ParseOmitPrivateData.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(message.isRfq()).to.be.true
     expect(message.toJSON()).to.deep.eq(ParseOmitPrivateData.output)
+    messageVerifyStub.resetHistory()
 
     // Parse with Rfq.parse()
     const rfq = await Rfq.parse(ParseOmitPrivateData.input)
+    expect(messageVerifyStub.calledOnce).to.be.true
     expect(rfq.isRfq()).to.be.true
     expect(rfq.toJSON()).to.deep.eq(ParseOmitPrivateData.output)
   })
@@ -99,11 +136,14 @@ describe('TbdexTestVectorsProtocol', function () {
   it('parse_balance', async () => {
     // Parse with parseResource()
     const resource = await Parser.parseResource(ParseBalance.input)
+    expect(resourceVerifyStub.calledOnce).to.be.true
     expect(resource.isBalance()).to.be.true
     expect(resource.toJSON()).to.deep.eq(ParseBalance.output)
+    resourceVerifyStub.resetHistory()
 
     // Parse with Balance.parse()
     const balance = await Balance.parse(ParseBalance.input)
+    expect(resourceVerifyStub.calledOnce).to.be.true
     expect(balance.isBalance()).to.be.true
     expect(balance.toJSON()).to.deep.eq(ParseBalance.output)
   })

--- a/packages/protocol/tests/test-vectors.spec.ts
+++ b/packages/protocol/tests/test-vectors.spec.ts
@@ -12,21 +12,21 @@ import { Parser } from '../src/parser.js'
 import Sinon from 'sinon'
 
 describe('TbdexTestVectorsProtocol', function () {
-  let messageVerifyStub: Sinon.SinonStub;
-  let resourceVerifyStub: Sinon.SinonStub;
+  let messageVerifyStub: Sinon.SinonStub
+  let resourceVerifyStub: Sinon.SinonStub
 
   beforeEach(function() {
     // Our intent here is to test the overall parsing logic,
     // so stub the signature verify methods to avoid real DID resolution over the network which can take more than 10 seconds for DID DHT
-    messageVerifyStub = Sinon.stub(Message.prototype, 'verify');
-    resourceVerifyStub = Sinon.stub(Resource.prototype, 'verify');
-  });
+    messageVerifyStub = Sinon.stub(Message.prototype, 'verify')
+    resourceVerifyStub = Sinon.stub(Resource.prototype, 'verify')
+  })
 
   afterEach(function() {
     // Restore the original method
-    messageVerifyStub.restore();
-    resourceVerifyStub.restore();
-  });
+    messageVerifyStub.restore()
+    resourceVerifyStub.restore()
+  })
 
   it('parse_close', async () => {
     // Parse with parseMessage()


### PR DESCRIPTION
These tests perform a signature verification which involves resolution of DID DHT DIDs that can take more than 10s from time to time causing the tests to fail.

With this change all these tests now take less than 1 millisecond to run combined.

The intent of these tests seems to be validating the parsing logic, thus I think we don't actually need the real signature verification so we can just mock it.

Test coverage remains the same as other test have hit the signature verification methods.