### PR TITLE
Updated HTTP request body according to spec change

### DIFF
--- a/.changeset/odd-owls-invite.md
+++ b/.changeset/odd-owls-invite.md
@@ -1,0 +1,7 @@
+---
+"@tbdex/protocol": major
+"@tbdex/http-client": major
+"@tbdex/http-server": major
+---
+
+Updated HTTP request body to contain `message` property according to spec change.

--- a/packages/http-client/src/client.ts
+++ b/packages/http-client/src/client.ts
@@ -71,7 +71,7 @@ export class TbdexHttpClient {
     await rfq.verify()
 
     const { to: pfiDid } = rfq.metadata
-    const requestBody = JSON.stringify({ rfq, replyTo: opts?.replyTo })
+    const requestBody = JSON.stringify({ message: rfq, replyTo: opts?.replyTo })
 
     await TbdexHttpClient.sendMessage(pfiDid, 'POST', `/exchanges`, requestBody)
   }

--- a/packages/http-client/src/client.ts
+++ b/packages/http-client/src/client.ts
@@ -87,7 +87,7 @@ export class TbdexHttpClient {
     await order.verify()
 
     const { to: pfiDid, exchangeId } = order.metadata
-    const requestBody = JSON.stringify(order)
+    const requestBody = JSON.stringify({ message: order })
 
     await TbdexHttpClient.sendMessage(pfiDid, 'PUT', `/exchanges/${exchangeId}`, requestBody)
   }
@@ -104,7 +104,7 @@ export class TbdexHttpClient {
 
     const { to: pfiDid, exchangeId } = close.metadata
 
-    const requestBody = JSON.stringify(close)
+    const requestBody = JSON.stringify({ message: close })
 
     await TbdexHttpClient.sendMessage(pfiDid, 'PUT', `/exchanges/${exchangeId}`, requestBody)
   }

--- a/packages/http-server/src/request-handlers/create-exchange.ts
+++ b/packages/http-server/src/request-handlers/create-exchange.ts
@@ -11,6 +11,9 @@ type CreateExchangeOpts = {
   exchangesApi: ExchangesApi
 }
 
+/**
+ * Handler for POST to /exchanges.
+ */
 export async function createExchange(req: Request, res: Response, options: CreateExchangeOpts): Promise<void> {
   const { offeringsApi, exchangesApi, callback } = options
   const replyTo: string | undefined = req.body.replyTo
@@ -23,7 +26,7 @@ export async function createExchange(req: Request, res: Response, options: Creat
   }
 
   try {
-    rfq = await Rfq.parse(req.body.rfq)
+    rfq = await Rfq.parse(req.body.message)
   } catch(e) {
     const errorResponse: ErrorDetail = { detail: `Parsing of TBDex Rfq message failed: ${e.message}` }
     res.status(400).json({ errors: [errorResponse] })

--- a/packages/http-server/src/request-handlers/create-exchange.ts
+++ b/packages/http-server/src/request-handlers/create-exchange.ts
@@ -12,7 +12,7 @@ type CreateExchangeOpts = {
 }
 
 /**
- * Handler for POST to /exchanges.
+ * Handler for POST to /exchanges to create a new exchange.
  */
 export async function createExchange(req: Request, res: Response, options: CreateExchangeOpts): Promise<void> {
   const { offeringsApi, exchangesApi, callback } = options

--- a/packages/http-server/src/request-handlers/submit-message.ts
+++ b/packages/http-server/src/request-handlers/submit-message.ts
@@ -17,7 +17,7 @@ export async function submitMessage(req: Request, res: Response, opts: SubmitMes
   let message: Message
 
   try {
-    message = await Parser.parseMessage(req.body)
+    message = await Parser.parseMessage(req.body.message)
   } catch(e) {
     const errorResponse: ErrorDetail = { detail: 'Request body was not a valid Order or Close message' }
     res.status(400).json({ errors: [errorResponse] })

--- a/packages/http-server/tests/create-exchange.spec.ts
+++ b/packages/http-server/tests/create-exchange.spec.ts
@@ -62,7 +62,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
     const resp = await fetch('http://localhost:8000/exchanges', {
       method : 'POST',
-      body   : JSON.stringify({ rfq: rfq, replyTo: 'foo' })
+      body   : JSON.stringify({ message: rfq, replyTo: 'foo' })
     })
 
     expect(resp.status).to.equal(400)
@@ -79,6 +79,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
     const aliceDid = await DidJwk.create()
     const pfiDid = await DidJwk.create()
 
+    // create an Order instead of RFQ
     const order = Order.create({
       metadata: {
         from       : aliceDid.uri,
@@ -90,7 +91,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
     const resp = await fetch('http://localhost:8000/exchanges', {
       method : 'POST',
-      body   : JSON.stringify({ rfq: order })
+      body   : JSON.stringify({ message: order })
     })
 
     expect(resp.status).to.equal(400)
@@ -112,7 +113,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
     const resp = await fetch('http://localhost:8000/exchanges', {
       method : 'POST',
-      body   : JSON.stringify({ rfq })
+      body   : JSON.stringify({ message: rfq })
     })
 
     expect(resp.status).to.equal(400)
@@ -136,7 +137,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
     const resp = await fetch('http://localhost:8000/exchanges', {
       method : 'POST',
-      body   : JSON.stringify({ rfq })
+      body   : JSON.stringify({ message: rfq })
     })
 
     expect(resp.status).to.equal(409)
@@ -169,7 +170,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
     const resp = await fetch('http://localhost:8000/exchanges', {
       method : 'POST',
-      body   : JSON.stringify({ rfq })
+      body   : JSON.stringify({ message: rfq })
     })
 
     expect(resp.status).to.equal(400)
@@ -206,7 +207,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
     const resp = await fetch('http://localhost:8000/exchanges', {
       method : 'POST',
-      body   : JSON.stringify({ rfq })
+      body   : JSON.stringify({ message: rfq })
     })
 
     expect(resp.status).to.equal(400)
@@ -311,7 +312,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
     it('returns a 202 if RFQ is accepted', async () => {
       const resp = await fetch('http://localhost:8000/exchanges', {
         method : 'POST',
-        body   : JSON.stringify({ rfq })
+        body   : JSON.stringify({ message: rfq })
       })
 
       expect(resp.status).to.equal(202)
@@ -326,7 +327,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
       const resp = await fetch('http://localhost:8000/exchanges', {
         method : 'POST',
-        body   : JSON.stringify({ rfq })
+        body   : JSON.stringify({ message: rfq })
       })
 
       expect(resp.status).to.equal(202)
@@ -351,7 +352,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
       const response = await fetch('http://localhost:8000/exchanges', {
         method : 'POST',
-        body   : JSON.stringify({ rfq })
+        body   : JSON.stringify({ message: rfq })
       })
 
       expect(response.status).to.equal(customErrorStatus)
@@ -369,7 +370,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
       const response = await fetch('http://localhost:8000/exchanges', {
         method : 'POST',
-        body   : JSON.stringify({ rfq })
+        body   : JSON.stringify({ message: rfq })
       })
 
       expect(response.status).to.equal(500)
@@ -389,7 +390,7 @@ describe('POST /exchanges/:exchangeId/rfq', () => {
 
       const resp = await fetch('http://localhost:8000/exchanges', {
         method : 'POST',
-        body   : JSON.stringify({ rfq, replyTo })
+        body   : JSON.stringify({ message: rfq, replyTo })
       })
 
       expect(resp.status).to.equal(202)

--- a/packages/http-server/tests/submit-close.spec.ts
+++ b/packages/http-server/tests/submit-close.spec.ts
@@ -51,7 +51,7 @@ describe('POST /exchanges/:exchangeId with a Close', () => {
     await close.sign(alice)
     const resp = await fetch('http://localhost:8000/exchanges/123', {
       method : 'PUT',
-      body   : JSON.stringify(close)
+      body   : JSON.stringify({ message: close })
     })
 
     expect(resp.status).to.equal(404)
@@ -100,7 +100,7 @@ describe('POST /exchanges/:exchangeId with a Close', () => {
     await close2.sign(alice)
     const resp = await fetch(`http://localhost:8000/exchanges/${exchangeId}`, {
       method : 'PUT',
-      body   : JSON.stringify(close2)
+      body   : JSON.stringify({ message: close2 })
     })
 
     expect(resp.status).to.equal(409)
@@ -141,7 +141,7 @@ describe('POST /exchanges/:exchangeId with a Close', () => {
 
     const resp = await fetch(`http://localhost:8000/exchanges/${rfq.metadata.exchangeId}`, {
       method : 'PUT',
-      body   : JSON.stringify(close)
+      body   : JSON.stringify({ message: close })
     })
 
     expect(resp.status).to.equal(202)
@@ -175,7 +175,7 @@ describe('POST /exchanges/:exchangeId with a Close', () => {
 
     const resp = await fetch(`http://localhost:8000/exchanges/${rfq.metadata.exchangeId}`, {
       method : 'PUT',
-      body   : JSON.stringify(close)
+      body   : JSON.stringify({ message: close })
     })
 
     expect(resp.status).to.equal(202)
@@ -209,7 +209,7 @@ describe('POST /exchanges/:exchangeId with a Close', () => {
 
     const resp = await fetch(`http://localhost:8000/exchanges/${rfq.metadata.exchangeId}`, {
       method : 'PUT',
-      body   : JSON.stringify(close)
+      body   : JSON.stringify({ message: close })
     })
 
     expect(resp.status).to.equal(400)
@@ -243,7 +243,7 @@ describe('POST /exchanges/:exchangeId with a Close', () => {
 
       const resp = await fetch('http://localhost:8000/exchanges/123', {
         method : 'PUT',
-        body   : JSON.stringify(close)
+        body   : JSON.stringify({ message: close })
       })
 
       expect(resp.status).to.equal(400)
@@ -279,7 +279,7 @@ describe('POST /exchanges/:exchangeId with a Close', () => {
 
       const resp = await fetch(`http://localhost:8000/exchanges/${rfq.metadata.exchangeId}`, {
         method : 'PUT',
-        body   : JSON.stringify(close)
+        body   : JSON.stringify({ message: close })
       })
 
       expect(resp.status).to.equal(202)

--- a/packages/http-server/tests/submit-message.spec.ts
+++ b/packages/http-server/tests/submit-message.spec.ts
@@ -51,7 +51,7 @@ describe('POST /exchanges/:exchangeId', () => {
 
     const resp = await fetch('http://localhost:8000/exchanges/123', {
       method : 'PUT',
-      body   : JSON.stringify(order)
+      body   : JSON.stringify({ message: order })
     })
 
     expect(resp.status).to.equal(400)
@@ -66,13 +66,15 @@ describe('POST /exchanges/:exchangeId', () => {
 
   it('returns a 400 if request body is not a valid close or order object', async () => {
     const alice = await DidJwk.create()
+
+    // creating an RFQ instead of an Order/close which is an invalid message to the path
     const rfq = await DevTools.createRfq({
       sender: alice
     })
     await rfq.sign(alice)
     const resp = await fetch(`http://localhost:8000/exchanges/${rfq.metadata.exchangeId}`, {
       method : 'PUT',
-      body   : JSON.stringify(rfq)
+      body   : JSON.stringify({ message: rfq })
     })
 
     expect(resp.status).to.equal(400)

--- a/packages/http-server/tests/submit-order.spec.ts
+++ b/packages/http-server/tests/submit-order.spec.ts
@@ -66,7 +66,7 @@ describe('POST /exchanges/:exchangeId with an Order', () => {
     await order.sign(aliceDid)
     const resp = await fetch('http://localhost:8000/exchanges/123', {
       method : 'PUT',
-      body   : JSON.stringify(order)
+      body   : JSON.stringify({ message: order })
     })
 
     expect(resp.status).to.equal(404)
@@ -103,7 +103,7 @@ describe('POST /exchanges/:exchangeId with an Order', () => {
 
     const resp = await fetch(`http://localhost:8000/exchanges/${rfq.metadata.exchangeId}`, {
       method : 'PUT',
-      body   : JSON.stringify(order)
+      body   : JSON.stringify({ message: order })
     })
 
     expect(resp.status).to.equal(409)
@@ -155,7 +155,7 @@ describe('POST /exchanges/:exchangeId with an Order', () => {
 
     const resp = await fetch(`http://localhost:8000/exchanges/${rfq.metadata.exchangeId}`, {
       method : 'PUT',
-      body   : JSON.stringify(order)
+      body   : JSON.stringify({ message: order })
     })
 
     expect(resp.status).to.equal(410)
@@ -209,7 +209,7 @@ describe('POST /exchanges/:exchangeId with an Order', () => {
 
     const resp = await fetch(`http://localhost:8000/exchanges/${rfq.metadata.exchangeId}`, {
       method : 'PUT',
-      body   : JSON.stringify(order)
+      body   : JSON.stringify({ message: order })
     })
 
     expect(resp.status).to.equal(202)
@@ -261,7 +261,7 @@ describe('POST /exchanges/:exchangeId with an Order', () => {
 
       const resp = await fetch(`http://localhost:8000/exchanges/${rfq.metadata.exchangeId}`, {
         method : 'PUT',
-        body   : JSON.stringify(order)
+        body   : JSON.stringify({ message: order })
       })
 
       expect(resp.status).to.equal(202)

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -55,7 +55,7 @@ const rfq = Rfq.create({
 
 await rfq.sign(alice)
 
-console.log(JSON.stringify(rfq, null, 2))
+console.log(JSON.stringify({ message: rfq }, null, 2))
 ```
 
 ## Message Parsing


### PR DESCRIPTION
Updated HTTP request body according to spec change in https://github.com/TBD54566975/tbdex/pull/344/files:
- Changed `rfq` property to `message` in create exchange request.
- Updated HTTP request body for `order` and `close` requests to have `message` container property.