### PR TITLE
Revert "Version Packages"

### DIFF
--- a/.changeset/selfish-apricots-act.md
+++ b/.changeset/selfish-apricots-act.md
@@ -1,0 +1,6 @@
+---
+"@tbdex/protocol": major
+"@tbdex/http-server": major
+---
+
+Updated code and tests to align with latest tbDEX spec (commit 621f54f of `tbdex` repo)

--- a/.changeset/shiny-pillows-smile.md
+++ b/.changeset/shiny-pillows-smile.md
@@ -1,0 +1,5 @@
+---
+"@tbdex/protocol": patch
+---
+
+Fix: use fragment in json schema refs.

--- a/packages/http-client/CHANGELOG.md
+++ b/packages/http-client/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @tbdex/http-client
 
-## 2.0.0
-
-### Patch Changes
-
-- Updated dependencies [[`fa3dfe8`](https://github.com/TBD54566975/tbdex-js/commit/fa3dfe870fdf14cd3516b020cba96fa29aa98c71), [`4c84157`](https://github.com/TBD54566975/tbdex-js/commit/4c841570d17682348b4edf1d5708616051a31eef)]:
-  - @tbdex/protocol@2.0.0
-
 ## 1.1.0
 
 ### Patch Changes

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbdex/http-client",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "type": "module",
   "description": "Http client that can be used to send tbdex messages",
   "license": "Apache-2.0",

--- a/packages/http-server/CHANGELOG.md
+++ b/packages/http-server/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @tbdex/http-server
 
-## 2.0.0
-
-### Major Changes
-
-- [#261](https://github.com/TBD54566975/tbdex-js/pull/261) [`fa3dfe8`](https://github.com/TBD54566975/tbdex-js/commit/fa3dfe870fdf14cd3516b020cba96fa29aa98c71) Thanks [@thehenrytsai](https://github.com/thehenrytsai)! - Updated code and tests to align with latest tbDEX spec (commit 621f54f of `tbdex` repo)
-
-### Patch Changes
-
-- Updated dependencies [[`fa3dfe8`](https://github.com/TBD54566975/tbdex-js/commit/fa3dfe870fdf14cd3516b020cba96fa29aa98c71), [`4c84157`](https://github.com/TBD54566975/tbdex-js/commit/4c841570d17682348b4edf1d5708616051a31eef)]:
-  - @tbdex/protocol@2.0.0
-  - @tbdex/http-client@2.0.0
-
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -9,7 +9,7 @@
   },
   "license": "Apache-2.0",
   "type": "module",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "module": "./dist/main.js",
   "types": "./dist/types/main.d.ts",
   "files": [

--- a/packages/protocol/CHANGELOG.md
+++ b/packages/protocol/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @tbdex/protocol
 
-## 2.0.0
-
-### Major Changes
-
-- [#261](https://github.com/TBD54566975/tbdex-js/pull/261) [`fa3dfe8`](https://github.com/TBD54566975/tbdex-js/commit/fa3dfe870fdf14cd3516b020cba96fa29aa98c71) Thanks [@thehenrytsai](https://github.com/thehenrytsai)! - Updated code and tests to align with latest tbDEX spec (commit 621f54f of `tbdex` repo)
-
-### Patch Changes
-
-- [#245](https://github.com/TBD54566975/tbdex-js/pull/245) [`4c84157`](https://github.com/TBD54566975/tbdex-js/commit/4c841570d17682348b4edf1d5708616051a31eef) Thanks [@diehuxx](https://github.com/diehuxx)! - Fix: use fragment in json schema refs.
-
 ## 1.1.0
 
 ### Patch Changes

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tbdex/protocol",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "type": "module",
   "description": "Library that includes type definitions for tbdex messages",
   "license": "Apache-2.0",


### PR DESCRIPTION
Reverts TBD54566975/tbdex-js#262

Because v2.0.0 was not properly released and we want to group with the #264 release